### PR TITLE
Update focus highlight to enlarge stop marker

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -863,6 +863,7 @@ public class StopOverlay implements MarkerListeners {
          */
         synchronized void setFocus(ObaStop stop) {
             if (stop == null) {
+                removeFocus();
                 return;
             }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -91,9 +91,9 @@ public class StopOverlay implements MarkerListeners {
 
     private static final int NUM_DIRECTIONS = 9; // 8 directions + undirected mStops
 
-    private static Bitmap[] bus_stop_icons = new Bitmap[NUM_DIRECTIONS];
+    private static final Bitmap[] bus_stop_icons = new Bitmap[NUM_DIRECTIONS];
 
-    private static Bitmap[] bus_stop_icons_focused = new Bitmap[NUM_DIRECTIONS];
+    private static final Bitmap[] bus_stop_icons_focused = new Bitmap[NUM_DIRECTIONS];
 
     private static final float FOCUS_ICON_SCALE = 1.25f;
 
@@ -860,6 +860,11 @@ public class StopOverlay implements MarkerListeners {
          * @param stop ObaStop that should have focus
          */
         void setFocus(ObaStop stop) {
+            if(stop == null) {
+                removeFocus();
+                return;
+            }
+
             if (mCurrentFocusMarker != null && mCurrentFocusStop != null) {
                 // Restore previous marker icon
                 mCurrentFocusMarker.setIcon(getBitmapDescriptorForBusStopDirection(

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -860,7 +860,7 @@ public class StopOverlay implements MarkerListeners {
          * @param stop ObaStop that should have focus
          */
         void setFocus(ObaStop stop) {
-            if(stop == null) {
+            if (stop == null) {
                 removeFocus();
                 return;
             }

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopOverlay.java
@@ -95,7 +95,7 @@ public class StopOverlay implements MarkerListeners {
 
     private static final Bitmap[] bus_stop_icons_focused = new Bitmap[NUM_DIRECTIONS];
 
-    private static final float FOCUS_ICON_SCALE = 1.25f;
+    private static final float FOCUS_ICON_SCALE = 1.5f;
 
     private static int mPx; // Bus stop icon size
 
@@ -233,18 +233,29 @@ public class StopOverlay implements MarkerListeners {
         mArrowPaintStroke.setStrokeWidth(1.0f);
         mArrowPaintStroke.setAntiAlias(true);
 
-        bus_stop_icons[0] = createBusStopIcon(NORTH);
-        bus_stop_icons[1] = createBusStopIcon(NORTH_WEST);
-        bus_stop_icons[2] = createBusStopIcon(WEST);
-        bus_stop_icons[3] = createBusStopIcon(SOUTH_WEST);
-        bus_stop_icons[4] = createBusStopIcon(SOUTH);
-        bus_stop_icons[5] = createBusStopIcon(SOUTH_EAST);
-        bus_stop_icons[6] = createBusStopIcon(EAST);
-        bus_stop_icons[7] = createBusStopIcon(NORTH_EAST);
-        bus_stop_icons[8] = createBusStopIcon(NO_DIRECTION);
+        bus_stop_icons[0] = createBusStopIcon(NORTH, false);
+        bus_stop_icons[1] = createBusStopIcon(NORTH_WEST, false);
+        bus_stop_icons[2] = createBusStopIcon(WEST, false);
+        bus_stop_icons[3] = createBusStopIcon(SOUTH_WEST, false);
+        bus_stop_icons[4] = createBusStopIcon(SOUTH, false);
+        bus_stop_icons[5] = createBusStopIcon(SOUTH_EAST, false);
+        bus_stop_icons[6] = createBusStopIcon(EAST, false);
+        bus_stop_icons[7] = createBusStopIcon(NORTH_EAST, false);
+        bus_stop_icons[8] = createBusStopIcon(NO_DIRECTION, false);
 
+        bus_stop_icons_focused[0] = createBusStopIcon(NORTH, true);
+        bus_stop_icons_focused[1] = createBusStopIcon(NORTH_WEST, true);
+        bus_stop_icons_focused[2] = createBusStopIcon(WEST, true);
+        bus_stop_icons_focused[3] = createBusStopIcon(SOUTH_WEST, true);
+        bus_stop_icons_focused[4] = createBusStopIcon(SOUTH, true);
+        bus_stop_icons_focused[5] = createBusStopIcon(SOUTH_EAST, true);
+        bus_stop_icons_focused[6] = createBusStopIcon(EAST, true);
+        bus_stop_icons_focused[7] = createBusStopIcon(NORTH_EAST, true);
+        bus_stop_icons_focused[8] = createBusStopIcon(NO_DIRECTION, true);
+
+        // Scale the focused icons to be larger than the normal icons
         for (int i = 0; i < NUM_DIRECTIONS; i++) {
-            Bitmap bmp = bus_stop_icons[i];
+            Bitmap bmp = bus_stop_icons_focused[i];
             bus_stop_icons_focused[i] = Bitmap.createScaledBitmap(bmp,
                     (int) (bmp.getWidth() * FOCUS_ICON_SCALE),
                     (int) (bmp.getHeight() * FOCUS_ICON_SCALE), true);
@@ -262,6 +273,21 @@ public class StopOverlay implements MarkerListeners {
      * if direction is NO_DIRECTION
      */
     private static Bitmap createBusStopIcon(String direction) throws NullPointerException {
+        return createBusStopIcon(direction, false);
+    }
+
+    /**
+     * Creates a bus stop icon with the given direction arrow, or without a direction arrow if
+     * the direction is NO_DIRECTION
+     *
+     * @param direction Bus stop direction, obtained from ObaStop.getDirection() and defined in
+     *                  constants in this class, or NO_DIRECTION if the stop icon shouldn't have a
+     *                  direction arrow
+     * @param selected true to use the selected icon style, false for normal icon style
+     * @return a bus stop icon bitmap with the arrow pointing the given direction, or with no arrow
+     * if direction is NO_DIRECTION
+     */
+    private static Bitmap createBusStopIcon(String direction, boolean selected) throws NullPointerException {
         if (direction == null) {
             throw new IllegalArgumentException(direction);
         }
@@ -283,13 +309,13 @@ public class StopOverlay implements MarkerListeners {
             // Don't draw the arrow
             bm = Bitmap.createBitmap(mPx, mPx, Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds(0, 0, bm.getWidth(), bm.getHeight());
         } else if (direction.equals(NORTH)) {
             directionAngle = 0f;
             bm = Bitmap.createBitmap(mPx, (int) (mPx + mBuffer), Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds(0, (int) mBuffer, mPx, bm.getHeight());
             // Shade with darkest color at tip of arrow
             arrowPaintFill.setShader(
@@ -304,7 +330,7 @@ public class StopOverlay implements MarkerListeners {
             bm = Bitmap.createBitmap((int) (mPx + mBuffer),
                     (int) (mPx + mBuffer), Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds((int) mBuffer, (int) mBuffer, bm.getWidth(), bm.getHeight());
             // Shade with darkest color at tip of arrow
             arrowPaintFill.setShader(
@@ -318,7 +344,7 @@ public class StopOverlay implements MarkerListeners {
             directionAngle = 0f;  // Arrow is drawn pointing West, so no rotation
             bm = Bitmap.createBitmap((int) (mPx + mBuffer), mPx, Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds((int) mBuffer, 0, bm.getWidth(), bm.getHeight());
             arrowPaintFill.setShader(
                     new LinearGradient(0, bm.getHeight() / 2, mArrowHeightPx, bm.getHeight() / 2,
@@ -332,7 +358,7 @@ public class StopOverlay implements MarkerListeners {
             bm = Bitmap.createBitmap((int) (mPx + mBuffer),
                     (int) (mPx + mBuffer), Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds((int) mBuffer, 0, bm.getWidth(), mPx);
             arrowPaintFill.setShader(
                     new LinearGradient(0, bm.getHeight(), mBuffer, bm.getHeight() - mBuffer,
@@ -345,7 +371,7 @@ public class StopOverlay implements MarkerListeners {
             directionAngle = 180f;  // Arrow is drawn N, rotate 180 degrees
             bm = Bitmap.createBitmap(mPx, (int) (mPx + mBuffer), Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds(0, 0, bm.getWidth(), (int) (bm.getHeight() - mBuffer));
             arrowPaintFill.setShader(
                     new LinearGradient(bm.getWidth() / 2, bm.getHeight(), bm.getWidth() / 2,
@@ -359,7 +385,7 @@ public class StopOverlay implements MarkerListeners {
             bm = Bitmap.createBitmap((int) (mPx + mBuffer),
                     (int) (mPx + mBuffer), Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds(0, 0, mPx, mPx);
             arrowPaintFill.setShader(
                     new LinearGradient(bm.getWidth(), bm.getHeight(), bm.getWidth() - mBuffer,
@@ -373,7 +399,7 @@ public class StopOverlay implements MarkerListeners {
             directionAngle = 180f;  // Arrow is drawn pointing West, so rotate 180
             bm = Bitmap.createBitmap((int) (mPx + mBuffer), mPx, Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds(0, 0, mPx, bm.getHeight());
             arrowPaintFill.setShader(
                     new LinearGradient(bm.getWidth(), bm.getHeight() / 2,
@@ -387,7 +413,7 @@ public class StopOverlay implements MarkerListeners {
             bm = Bitmap.createBitmap((int) (mPx + mBuffer),
                     (int) (mPx + mBuffer), Bitmap.Config.ARGB_8888);
             c = new Canvas(bm);
-            shape = ContextCompat.getDrawable(context, R.drawable.map_stop_icon);
+            shape = ContextCompat.getDrawable(context, selected ? R.drawable.selected_map_stop_icon : R.drawable.map_stop_icon);
             shape.setBounds(0, (int) mBuffer, mPx, bm.getHeight());
             // Shade with darkest color at tip of arrow
             arrowPaintFill.setShader(

--- a/onebusaway-android/src/main/res/drawable/selected_map_stop_icon.xml
+++ b/onebusaway-android/src/main/res/drawable/selected_map_stop_icon.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Drop Shadow Stack -->
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="#02b7b7b7"/>
+            <size
+                    android:width="@dimen/map_stop_shadow_size_6"
+                    android:height="@dimen/map_stop_shadow_size_6"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="#05b7b7b7"/>
+            <size
+                    android:width="@dimen/map_stop_shadow_size_5"
+                    android:height="@dimen/map_stop_shadow_size_5"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="@android:color/transparent"
+                    android:width="1dp"/>
+            <solid android:color="#10b7b7b7"/>
+            <size
+                    android:width="@dimen/map_stop_shadow_size_4"
+                    android:height="@dimen/map_stop_shadow_size_4"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="@android:color/transparent"
+                    android:width="2dp"/>
+            <solid android:color="#15b7b7b7"/>
+            <size
+                    android:width="@dimen/map_stop_shadow_size_3"
+                    android:height="@dimen/map_stop_shadow_size_3"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="@android:color/transparent"
+                    android:width="3dp"/>
+            <solid android:color="#20b7b7b7"/>
+            <size
+                    android:width="@dimen/map_stop_shadow_size_2"
+                    android:height="@dimen/map_stop_shadow_size_2"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="@android:color/transparent"
+                    android:width="4dp"/>
+            <solid android:color="#25b7b7b7"/>
+            <size
+                    android:width="@dimen/map_stop_shadow_size_1"
+                    android:height="@dimen/map_stop_shadow_size_1"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="@android:color/transparent"
+                    android:width="4dp"/>
+            <solid android:color="#30b7b7b7"/>
+            <size
+                    android:width="@dimen/map_stop_shadow_size_1"
+                    android:height="@dimen/map_stop_shadow_size_1"/>
+        </shape>
+    </item>
+    <!-- White outline -->
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="@android:color/transparent"
+                    android:width="4dp"/>
+            <solid android:color="@android:color/white"/>
+            <size
+                    android:width="@dimen/map_stop_icon_size"
+                    android:height="@dimen/map_stop_icon_size"/>
+        </shape>
+    </item>
+    <!-- Fill - Changed to orange color for selected state -->
+    <item>
+        <shape android:shape="oval">
+            <stroke
+                    android:width="7dp"
+                    android:color="@android:color/transparent"/>
+            <solid android:color="#FF9500"/>
+            <size
+                    android:width="@dimen/map_stop_icon_size_fill"
+                    android:height="@dimen/map_stop_icon_size_fill"/>
+        </shape>
+    </item>
+    <!-- Black dot in the center -->
+    <item android:gravity="center">
+        <shape android:shape="oval">
+            <solid android:color="@android:color/black"/>
+            <size
+                    android:width="6dp"
+                    android:height="6dp"/>
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
## Summary
- scale focused stop markers instead of adding a separate marker
- generate enlarged bitmaps for focused state
- update focus handling logic to swap marker icons

## Testing
- `./gradlew assembleObaGoogleDebug`
- `./gradlew connectedObaGoogleDebugAndroidTest` *(fails: No connected devices)*

------
https://chatgpt.com/codex/tasks/task_e_68583c35208c83329ded2ae933998837