### PR TITLE
Fix stop selection retention after viewing trip status

### DIFF
--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.java
@@ -476,6 +476,12 @@ public class HomeActivity extends AppCompatActivity
         mFabMyLocation.requestLayout();
 
         updateDonationsUIVisibility();
+
+        // Ensure the map retains the currently selected stop when returning
+        // from another Activity (e.g., TripDetailsActivity)
+        if (mFocusedStop != null && mMapFragment != null) {
+            mMapFragment.setFocusStop(mFocusedStop, null);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- keep stop focused in map when resuming HomeActivity

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685882bcff8c8332b90d3d0513322746