### PR TITLE
Trip planner: typed endpoints with cancellable pills + Geocoder fallback

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleCameraCommands.kt
@@ -26,6 +26,7 @@ import org.onebusaway.android.R
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.map.googlemapsv2.MapHelpV2
 import org.onebusaway.android.map.render.CameraCommand
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.util.ViewUtils
 import kotlin.math.abs
@@ -35,17 +36,15 @@ private const val CAMERA_DEFAULT_ZOOM = 16.0f
 private const val DEFAULT_MAP_PADDING_DP = 20.0f
 
 /**
- * Applies one [CameraCommand] to the imperative [GoogleMap] — a faithful port of the `GoogleMapHost`
- * methods that called `mMap.animateCamera/moveCamera` directly (the maps-compose `CameraPositionState`
- * detour is gone). The math (bounds, the route-header recenter bias, the closest-vehicle visibility
- * short-circuit) is unchanged, now reading the live camera from [map] and the route shape from
- * [renderState]. Google's camera calls are fire-and-forget, so this is not a suspend function.
+ * Applies one transient [CameraCommand] gesture to the imperative [GoogleMap] — a faithful port of the
+ * `GoogleMapHost` methods that called `mMap.animateCamera/moveCamera` directly (the maps-compose
+ * `CameraPositionState` detour is gone). The route-header recenter bias is unchanged, now reading the
+ * live camera from [map]. Google's camera calls are fire-and-forget, so this is not a suspend function.
+ * Retained framing (fit route / itinerary / region) is applied by [applyFramingIntent].
  */
 fun applyCameraCommand(
     cmd: CameraCommand,
     map: GoogleMap,
-    renderState: MapRenderState,
-    context: Context,
 ) {
     when (cmd) {
         is CameraCommand.Recenter -> {
@@ -85,36 +84,6 @@ fun applyCameraCommand(
 
         is CameraCommand.SetZoom -> map.moveCamera(CameraUpdateFactory.zoomTo(cmd.zoom))
 
-        CameraCommand.FitToRoute -> {
-            val bounds = routePolylineBounds(renderState)
-            if (bounds == null) {
-                Toast.makeText(context, R.string.route_info_no_shape_data, Toast.LENGTH_SHORT).show()
-            } else {
-                map.moveCamera(
-                    CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP))
-                )
-            }
-        }
-
-        CameraCommand.FitToItinerary -> {
-            val bounds = routePolylineBounds(renderState) ?: return
-            val dm = context.resources.displayMetrics
-            map.moveCamera(
-                CameraUpdateFactory.newLatLngBounds(
-                    bounds, dm.widthPixels, dm.heightPixels,
-                    ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP)
-                )
-            )
-        }
-
-        CameraCommand.ZoomToRegion -> {
-            val region = Application.get().currentRegion ?: return
-            val bounds = MapHelpV2.getRegionBounds(region)
-            // Use screen dimensions to avoid IllegalStateException (#581).
-            val dm = context.resources.displayMetrics
-            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, dm.widthPixels, dm.heightPixels, 0))
-        }
-
         CameraCommand.ZoomIn -> map.animateCamera(CameraUpdateFactory.zoomIn())
 
         CameraCommand.ZoomOut -> map.animateCamera(CameraUpdateFactory.zoomOut())
@@ -127,6 +96,55 @@ fun applyCameraCommand(
                 )
             )
         }
+    }
+}
+
+/**
+ * Applies the map's retained [FramingIntent] to the imperative [GoogleMap] — the bounds/target math
+ * ported unchanged from the former `FitToRoute`/`FitToItinerary`/`ZoomToRegion` camera commands,
+ * re-reading the route shape from [renderState] and the region bounds live so it's safe to re-apply when
+ * a re-created adapter replays the current framing. Fire-and-forget, so not a suspend function.
+ */
+fun applyFramingIntent(
+    intent: FramingIntent,
+    map: GoogleMap,
+    renderState: MapRenderState,
+    context: Context,
+) {
+    when (intent) {
+        FramingIntent.Route -> {
+            val bounds = routePolylineBounds(renderState)
+            if (bounds == null) {
+                Toast.makeText(context, R.string.route_info_no_shape_data, Toast.LENGTH_SHORT).show()
+            } else {
+                map.moveCamera(
+                    CameraUpdateFactory.newLatLngBounds(bounds, ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP))
+                )
+            }
+        }
+
+        FramingIntent.Itinerary -> {
+            val bounds = routePolylineBounds(renderState) ?: return
+            val dm = context.resources.displayMetrics
+            map.moveCamera(
+                CameraUpdateFactory.newLatLngBounds(
+                    bounds, dm.widthPixels, dm.heightPixels,
+                    ViewUtils.dpToPixels(context, DEFAULT_MAP_PADDING_DP)
+                )
+            )
+        }
+
+        FramingIntent.Region -> {
+            val region = Application.get().currentRegion ?: return
+            val bounds = MapHelpV2.getRegionBounds(region)
+            // Use screen dimensions to avoid IllegalStateException (#581).
+            val dm = context.resources.displayMetrics
+            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, dm.widthPixels, dm.heightPixels, 0))
+        }
+
+        is FramingIntent.Point -> map.moveCamera(
+            CameraUpdateFactory.newLatLngZoom(LatLng(intent.lat, intent.lon), intent.zoom)
+        )
     }
 }
 

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -48,9 +48,9 @@ import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.android.gms.maps.model.Marker
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onSubscription
 import org.onebusaway.android.R
 import org.onebusaway.android.map.MapHost
 import org.onebusaway.android.map.compose.BikeInfoWindow
@@ -79,8 +79,9 @@ private const val FRAME_INTERVAL_NANOS = 50_000_000L
  * android-maps-compose), bridging the MapView's imperative lifecycle to Compose via a
  * [LifecycleEventObserver], and drives the shared [MapHost]. It sets the style, builds the
  * [GoogleMapRenderer] and re-renders on every render-state change, wires map/marker/info-window clicks
- * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the dispatched camera intents,
- * and enables the location blue dot from the host's permission-derived flag.
+ * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the render state's camera
+ * gestures + retained framing intent, and enables the location blue dot from the host's
+ * permission-derived flag.
  *
  * The live route vehicles + the trip-focus estimate markers are native [Marker]s moved in place at
  * ~20Hz (the [GoogleMapRenderer.renderDynamic] loop below), so they glide with the map — no Compose
@@ -245,19 +246,16 @@ class GoogleComposeAdapter : ObaComposeMapAdapter {
             LaunchedEffect(map) {
                 renderState.padding.collect { map.setPadding(0, it.topPx, 0, it.bottomPx) }
             }
-            // Declarative camera: apply the host-dispatched camera intents to the map once ready, and
-            // tell the host the adapter is subscribed (so a deferred route re-frame can dispatch now).
-            DisposableEffect(map) {
-                host.setMapAttached(true)
-                onDispose { host.setMapAttached(false) }
+            // Declarative camera. Transient gestures apply as they arrive (dropped if none pending when
+            // the map wasn't subscribed). The retained framing intent is replayed to this collector when
+            // the map (re)composes, so a fit requested before the adapter subscribed — the directions map
+            // composed behind the results sheet (#1640), or a re-tap of the already-shown route — is
+            // re-applied here rather than deferred through a host flag; null clears it (no framing to apply).
+            LaunchedEffect(map) {
+                renderState.cameraGestures.collect { applyCameraCommand(it, map) }
             }
             LaunchedEffect(map) {
-                renderState.cameraCommands
-                    // Flush any frame deferred while the map was detached the moment this collector is
-                    // registered — emissions made in onSubscription are delivered here, so a deferred
-                    // fit isn't dropped by the no-replay flow if the first camera-idle beats us (#1640).
-                    .onSubscription { host.onCameraCommandsSubscribed() }
-                    .collect { applyCameraCommand(it, map, renderState, context) }
+                renderState.framingIntent.filterNotNull().collect { applyFramingIntent(it, map, renderState, context) }
             }
             // Publish a flavor-neutral lat/lng -> root-space projector so map-SDK-agnostic callers (the
             // onboarding spotlight) can locate a marker on screen without touching the Google SDK.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -22,7 +22,6 @@ import android.content.Context;
 import android.hardware.GeomagneticField;
 import android.location.Location;
 import android.os.Build;
-import android.os.PowerManager;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -409,20 +408,6 @@ public class Application extends android.app.Application {
             manager.createNotificationChannel(channel2);
             manager.createNotificationChannel(channel3);
         }
-    }
-
-    public static Boolean isIgnoringBatteryOptimizations(Context applicationContext) {
-        PowerManager pm = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                pm.isIgnoringBatteryOptimizations(applicationContext.getPackageName())) {
-            return true;
-        }
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return null;
-        }
-
-        return false;
     }
 
     private void initFirebaseMessaging() {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -274,46 +274,6 @@ public class Application extends android.app.Application {
         PreferenceUtils.saveString(getString(R.string.preference_key_oba_api_url), url);
     }
 
-    /**
-     * Returns the custom OTP URL if the user has set a custom API URL manually via Preferences, or
-     * null
-     * if it has not been set
-     *
-     * @return the custom URL if the user has set a custom API URL manually via Preferences, or null
-     * if it has not been set
-     */
-    public String getCustomOtpApiUrl() {
-        return PreferenceUtils.getString(getString(R.string.preference_key_otp_api_url));
-    }
-
-    /**
-     * Sets the custom OTP URL used to reach a OBA REST API server that is not available via the
-     * Regions
-     * REST API
-     *
-     * @param url the custom URL
-     */
-    public void setCustomOtpApiUrl(String url) {
-        PreferenceUtils.saveString(getString(R.string.preference_key_otp_api_url), url);
-    }
-
-    /**
-     * @return true if the OTP url version is old, or false  if it has not been set
-     */
-    public boolean getUseOldOtpApiUrlVersion() {
-        return PreferenceUtils.getBoolean(getString(R.string.preference_key_otp_api_url_version), false);
-    }
-
-    /**
-     * Sets the OTP Api url version
-     *
-     * @param useOldOtpApiUrlVersion indicates that if otp url structure belongs to older version
-     */
-    public void setUseOldOtpApiUrlVersion(boolean useOldOtpApiUrlVersion) {
-        PreferenceUtils.saveBoolean(getString(R.string.preference_key_otp_api_url_version),
-                useOldOtpApiUrlVersion);
-    }
-
     private static final String HEXES = "0123456789abcdef";
 
     public static String getHex(byte[] raw) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/app/Application.java
@@ -40,7 +40,6 @@ import org.onebusaway.android.util.BuildFlavorUtils;
 import org.onebusaway.android.util.LocationUtils;
 import org.onebusaway.android.util.PreferenceUtils;
 import org.onebusaway.android.util.ThemeUtils;
-import org.onebusaway.android.widealerts.GtfsAlerts;
 
 import java.security.MessageDigest;
 import java.util.UUID;
@@ -66,8 +65,6 @@ public class Application extends android.app.Application {
     public static final String CHANNEL_DESTINATION_ALERT_ID = "destination_alerts";
 
     private DonationsManager mDonationsManager;
-
-    private GtfsAlerts mGtfsAlerts;
 
     private static Application mApp;
 
@@ -109,8 +106,6 @@ public class Application extends android.app.Application {
         initFirebaseMessaging();
 
         mDonationsManager = new DonationsManager(getApplicationContext(), getResources(), getAppLaunchCount());
-
-        mGtfsAlerts = new GtfsAlerts(getApplicationContext());
     }
 
     /**
@@ -132,10 +127,6 @@ public class Application extends android.app.Application {
     }
 
     public static DonationsManager getDonationsManager() { return get().mDonationsManager; }
-
-    public static GtfsAlerts getGtfsAlerts() {
-        return get().mGtfsAlerts;
-    }
 
 
     // Preserve the original preference-key value so persisted launch counts survive upgrades.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -23,12 +23,15 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import androidx.lifecycle.SavedStateHandle
 import org.onebusaway.android.R
 import org.onebusaway.android.location.LocationRepository
 import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.preferences.PreferencesRepository
@@ -94,47 +97,6 @@ class MapHost(
         savedStateHandle[MapParams.CENTER_LAT] = snapshot.center.latitude
         savedStateHandle[MapParams.CENTER_LON] = snapshot.center.longitude
         savedStateHandle[MapParams.ZOOM] = snapshot.zoom.toFloat()
-        // Apply any frame deferred while the map wasn't ready, but ONLY once the adapter's command
-        // collector is actually subscribed — not merely attached. [setMapAttached] runs in a
-        // DisposableEffect that fires *before* the separate LaunchedEffect that subscribes to
-        // [MapRenderState.cameraCommands], so there's a window where mapAttached is true but no collector
-        // exists yet; a map tearing down likewise reports a final idle after its collector is gone.
-        // Flushing then would dispatch the pending frame into a no-replay flow with no subscriber, losing
-        // it and stranding the camera at the (0,0) seed. This path only covers the
-        // "attached + subscribed but not yet idled" window (e.g. a region resolving just after attach);
-        // the reliable flush on (re)attach is [onCameraCommandsSubscribed].
-        if (mapAttached && cameraCommandsSubscribed) applyDeferredCameraFrames()
-    }
-
-    /**
-     * Apply any camera frame requested while the map was detached: the region re-zoom ([rezoomForRegion]),
-     * the route re-fit ([frameRoute]), or the directions itinerary fit ([frameItinerary]). The
-     * camera-command flow has no replay, so a frame dispatched before a collector exists is lost —
-     * these deferrals hold the intent until the map is ready, then dispatch it against a live subscriber.
-     */
-    private fun applyDeferredCameraFrames() {
-        if (pendingRegionFrame) {
-            pendingRegionFrame = false
-            frameCurrentRegion()
-        }
-        if (pendingFrameCommands.isNotEmpty()) {
-            val commands = pendingFrameCommands
-            pendingFrameCommands = emptyList()
-            commands.forEach { dispatchCamera(it) }
-        }
-    }
-
-    /**
-     * The flavor adapter calls this the instant it subscribes to [MapRenderState.cameraCommands] (from
-     * `Flow.onSubscription`), so a frame deferred while the map was detached is dispatched against a
-     * guaranteed-live collector rather than racing it. The first `onCameraIdle` can fire *before* the
-     * adapter's collector is registered — with a no-replay command flow that dropped the deferred frame,
-     * leaving the camera at the (0,0) world seed (the trip-plan directions map, drawn behind the results
-     * sheet the moment a plan completes, hit this every time).
-     */
-    fun onCameraCommandsSubscribed() {
-        cameraCommandsSubscribed = true
-        applyDeferredCameraFrames()
     }
 
     /**
@@ -194,85 +156,50 @@ class MapHost(
 
     fun setBottomPadding(px: Int) = renderState.setBottomPadding(px)
 
-    fun dispatchCamera(command: CameraCommand) = renderState.dispatchCamera(command)
+    /** Dispatch a transient camera gesture (zoom step / recenter / my-location move / stop-tap center). */
+    fun dispatchGesture(command: CameraCommand) = renderState.dispatchGesture(command)
 
-    // Whether a flavor map adapter is currently composed. Toggled by the adapter on composition
-    // enter/leave; lets [frameOrDefer] choose between dispatching now and deferring.
-    private var mapAttached = false
+    /** Set the map's retained framing intent (fit route / itinerary / region / a fixed point). */
+    fun frame(intent: FramingIntent) = renderState.frame(intent)
 
-    // Whether the adapter's [MapRenderState.cameraCommands] collector is actually subscribed. Distinct
-    // from [mapAttached] because the adapter sets attached in a DisposableEffect that runs *before* the
-    // LaunchedEffect that subscribes, so there's an attached-but-not-subscribed window; a deferred flush
-    // into the no-replay command flow during it would be lost. Set on subscribe ([onCameraCommandsSubscribed]),
-    // cleared on detach so a re-attach re-arms it.
-    private var cameraCommandsSubscribed = false
-
-    // Set when a framing move (route/itinerary bounds fit, or the degenerate directions start-center) is
-    // requested while the map is detached — the camera-command flow has no replay, so a command
-    // dispatched before the adapter (re)subscribes is lost. Holds the latest such frame's commands until
-    // the map is ready (see [frameOrDefer]); a single pending frame is enough because a given host only
-    // ever fits one thing (the home map fits a route, the trip-results map fits an itinerary), but the
-    // start-center frame is two commands (recenter + zoom), so it's a list. The region re-zoom is
-    // deferred separately via [pendingRegionFrame] because it runs decision logic ([frameCurrentRegion]).
-    private var pendingFrameCommands: List<CameraCommand> = emptyList()
-
-    /** The flavor adapter reports when its render-state subscription starts/ends (the map composable enter/leave). */
-    fun setMapAttached(attached: Boolean) {
-        mapAttached = attached
-        if (!attached) cameraCommandsSubscribed = false
-    }
+    /** Clear the retained framing so a stale fit isn't re-applied when the map leaves a framed view. */
+    fun clearFraming() = renderState.clearFraming()
 
     /**
-     * Dispatch a framing move now when the map adapter's command collector is subscribed; otherwise hold
-     * it until the map is ready (flushed by [onCameraCommandsSubscribed], or [applyDeferredCameraFrames]
-     * on the first idle), so a frame isn't dropped into the no-replay command flow when it's requested
-     * against a map that's attached but hasn't subscribed yet (the [setMapAttached] DisposableEffect runs
-     * before the subscribing LaunchedEffect). The shape/route is already in the render state, so a
-     * deferred bounds-fit has bounds to fit.
+     * Frame the active route's bounding box (the "zoom to route" camera move). Sets the retained
+     * [FramingIntent.Route], so a late or re-created adapter replays it — the frame isn't dropped when
+     * re-selecting the already-shown route from a list that navigates back to a freshly re-created map
+     * (the recent-routes case), nor swallowed when re-tapping the same route to snap back to its extent.
+     * The route's shape is already in the render state, so the framing has bounds to fit.
      */
-    private fun frameOrDefer(vararg commands: CameraCommand) {
-        if (mapAttached && cameraCommandsSubscribed) {
-            commands.forEach { dispatchCamera(it) }
-        } else {
-            pendingFrameCommands = commands.toList()
-        }
-    }
+    fun frameRoute() = frame(FramingIntent.Route)
 
     /**
-     * Frame the active route's bounding box (the "zoom to route" camera move). Deferred if the map isn't
-     * ready — e.g. re-selecting the already-shown route from a list that navigates back to a freshly
-     * re-created map (the recent-routes case).
-     */
-    fun frameRoute() = frameOrDefer(CameraCommand.FitToRoute)
-
-    /**
-     * Frame the current directions itinerary's bounding box. Deferred if the map isn't ready — the
+     * Frame the current directions itinerary's bounding box. Retained, so it isn't lost when the
      * directions map is composed behind the results sheet the instant a plan completes, before the
-     * adapter subscribes to the command flow.
+     * adapter subscribes (#1640) — the replay catches the late subscriber up.
      */
-    fun frameItinerary() = frameOrDefer(CameraCommand.FitToItinerary)
+    fun frameItinerary() = frame(FramingIntent.Itinerary)
 
     /**
      * Frame a degenerate directions itinerary (no route shape — start == end): center on [lat],[lon] at
-     * the default zoom. Deferred like [frameItinerary] if the map isn't ready, since it's dispatched at
-     * the same moment (a plan completing behind the results sheet) and the command flow has no replay.
+     * the default zoom. Retained like [frameItinerary] since it's requested at the same moment (a plan
+     * completing behind the results sheet).
      */
-    fun frameStart(lat: Double, lon: Double) = frameOrDefer(
-        CameraCommand.Recenter(lat, lon, animate = false, applyRouteBias = false),
-        CameraCommand.SetZoom(MapParams.DEFAULT_ZOOM.toFloat()),
-    )
+    fun frameStart(lat: Double, lon: Double) =
+        frame(FramingIntent.Point(lat, lon, MapParams.DEFAULT_ZOOM.toFloat()))
 
     /** Animate/move the camera to a point with no route-header bias (a general recenter for any screen). */
     fun centerOn(lat: Double, lon: Double, animate: Boolean) {
-        dispatchCamera(CameraCommand.Recenter(lat, lon, animate, applyRouteBias = false))
+        dispatchGesture(CameraCommand.Recenter(lat, lon, animate, applyRouteBias = false))
     }
 
-    fun zoomIn() = dispatchCamera(CameraCommand.ZoomIn)
+    fun zoomIn() = dispatchGesture(CameraCommand.ZoomIn)
 
-    fun zoomOut() = dispatchCamera(CameraCommand.ZoomOut)
+    fun zoomOut() = dispatchGesture(CameraCommand.ZoomOut)
 
     /** Frame the current region's bounds (the out-of-range dialog's "take me there"). */
-    fun zoomToRegion() = dispatchCamera(CameraCommand.ZoomToRegion)
+    fun zoomToRegion() = frame(FramingIntent.Region)
 
     // ----- Generic markers -----
 
@@ -343,7 +270,7 @@ class MapHost(
         )
         when (action) {
             MyLocationAction.MoveToLocation -> last?.let {
-                dispatchCamera(
+                dispatchGesture(
                     CameraCommand.MoveToLocation(it.latitude, it.longitude, useDefaultZoom, animate)
                 )
             }
@@ -356,37 +283,40 @@ class MapHost(
 
     // ----- Region re-zoom (the old ObaRegionsTask.Callback.onRegionTaskFinished) -----
 
-    // Set when a region change wants to re-center but the map hasn't published its camera yet — the
-    // camera-command flow has no replay, so a command dispatched before the adapter subscribes is lost.
-    // Consumed on the first onCameraIdle (when the adapter is definitely subscribed).
-    private var pendingRegionFrame = false
-
     /**
      * The current region changed (driven by the region collector, so this only fires on a real change to
-     * a present region). Frames it once the map is ready; if the map hasn't published a camera yet, defer
-     * to the first [onCameraIdle] so the camera command isn't lost.
+     * a present region). Frames it once the map has published a camera — awaiting the first non-null
+     * [camera] reactively rather than deferring through a boolean flushed in [onCameraIdle]. Waiting for
+     * the camera lets the `cameraAtSeed` decision read the real restored/seed viewport (not a premature
+     * null). Both outcomes are retained framings ([FramingIntent]), so the frame survives even if the
+     * first camera idle beats the adapter's subscription (#1640) — the exact seed-window this decision
+     * runs in — rather than being dropped into the no-replay gesture flow.
      */
     private fun rezoomForRegion() {
-        if (_camera.value == null) {
-            pendingRegionFrame = true
-            return
+        scope.launch {
+            val cam = camera.filterNotNull().first()
+            frameCurrentRegion(cam)
         }
-        frameCurrentRegion()
     }
 
     /**
      * Frame the current region: if we have no location, or the camera is still at the (0,0) seed, frame
      * the user's location if we have one, else the region — but don't yank a camera the user already moved.
+     * Both frames go through the retained [FramingIntent] flow (not the FAB's [requestMyLocation] gesture
+     * path), so neither can be lost in the first-idle-before-subscribe window this cold-start decision
+     * runs in. The my-location leg has already established a fix here (regionRezoom returns FrameMyLocation
+     * only when one exists), so it centers on it directly rather than re-deriving the FAB's dialog logic.
      */
-    private fun frameCurrentRegion() {
+    private fun frameCurrentRegion(cam: CameraSnapshot) {
         // lastKnownLocation() (not the repo's .value): this runs at cold-start framing and must trigger
         // the lazy provider poll so the first frame can target the user's location.
         val location = locationRepository.lastKnownLocation()
-        val center = _camera.value?.center
-        val atSeed = center == null || (center.latitude == 0.0 && center.longitude == 0.0)
+        val center = cam.center
+        val atSeed = center.latitude == 0.0 && center.longitude == 0.0
         when (regionRezoom(changed = true, hasLocation = location != null, cameraAtSeed = atSeed)) {
-            RegionRezoom.FrameMyLocation -> requestMyLocation(useDefaultZoom = true, animate = false)
-            RegionRezoom.FrameRegion -> dispatchCamera(CameraCommand.ZoomToRegion)
+            RegionRezoom.FrameMyLocation ->
+                location?.let { frame(FramingIntent.Point(it.latitude, it.longitude, SEED_DEFAULT_ZOOM)) }
+            RegionRezoom.FrameRegion -> frame(FramingIntent.Region)
             RegionRezoom.None -> {}
         }
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -283,6 +283,10 @@ class MapViewModel @Inject constructor(
         stopsController.clearStops(false)
         mapHost.setProgress(false)
         mapHost.setMoreStopsAvailable(false)
+        // Drop any retained framing (route/itinerary/region fit) so it isn't replayed onto the next view
+        // — e.g. a stale route fit re-applied when a re-created adapter re-subscribes in nearby-stops
+        // mode. The view we enter next sets its own framing (or none, for nearby stops).
+        mapHost.clearFraming()
     }
 
     // ----- Focus + taps (delegated to [stopsController], except the vehicle selection) -----
@@ -306,7 +310,7 @@ class MapViewModel @Inject constructor(
 
     /** Recenter on the focused stop after the arrivals sheet expands over it (a Home map directive). */
     fun recenterOnFocusedStop(lat: Double, lon: Double) {
-        mapHost.dispatchCamera(
+        mapHost.dispatchGesture(
             CameraCommand.Recenter(lat, lon, animate = true, applyRouteBias = routeController.isActive)
         )
     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -205,7 +205,7 @@ class StopsMapController(
     fun onStopTapped(stop: ObaStop) {
         setFocusedStopId(stop.id)
         val loc = stop.location
-        host.dispatchCamera(CameraCommand.CenterOnStopTap(loc.latitude, loc.longitude))
+        host.dispatchGesture(CameraCommand.CenterOnStopTap(loc.latitude, loc.longitude))
     }
 
     /** A tap away from any marker clears the stop render focus (the old onMapClick). */
@@ -220,7 +220,7 @@ class StopsMapController(
      */
     fun focusStop(stop: ObaStop, routes: List<ObaRoute>?, overlayExpanded: Boolean) {
         val loc = stop.location
-        host.dispatchCamera(
+        host.dispatchGesture(
             CameraCommand.Recenter(
                 loc.latitude, loc.longitude,
                 animate = false,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/TripFocusController.kt
@@ -26,7 +26,7 @@ import org.onebusaway.android.extrapolation.extrapolationFromState
 import org.onebusaway.android.time.WallTime
 import org.onebusaway.android.extrapolation.data.TripObservationRepository
 import org.onebusaway.android.map.render.BandSegment
-import org.onebusaway.android.map.render.CameraCommand
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.RoutePolyline
 import org.onebusaway.android.map.render.TripOverlay
 import org.onebusaway.android.map.render.TripStopDot
@@ -88,7 +88,7 @@ class TripFocusController(
                     )
                 )
             )
-            host.dispatchCamera(CameraCommand.FitToRoute)
+            host.frame(FramingIntent.Route)
         }
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/CameraCommand.kt
@@ -16,15 +16,18 @@
 package org.onebusaway.android.map.render
 
 /**
- * A one-shot camera intent. A use-case controller dispatches one of these to
- * [MapRenderState.cameraCommands], and the flavor adapter applies it against its imperative map
- * (`GoogleMap`/`MapLibreMap.animateCamera(...)`) — so the camera is driven from state, decoupled from
- * any one screen, rather than poked directly on the map.
+ * A one-shot, **transient** camera gesture (zoom step, recenter, my-location move, stop-tap centering).
+ * A use-case controller dispatches one of these to [MapRenderState.cameraGestures], and the flavor
+ * adapter applies it against its imperative map (`GoogleMap`/`MapLibreMap.animateCamera(...)`) — so the
+ * camera is driven from state, decoupled from any one screen, rather than poked directly on the map.
+ *
+ * Transient: a gesture dispatched while no map is subscribed is *meant* to be discarded (the flow has no
+ * replay). Persistent framing — fit the route / itinerary / region — is the separate [FramingIntent],
+ * which is retained so a late subscriber catches up.
  *
  * Flavor-neutral: it carries *intent*, never a Google/maplibre `CameraUpdate`. The renderer computes
- * the actual bounds/target from the current render state + the live viewport. Bounds-fitting commands
- * read [MapRenderSnapshot.routePolylines]; framing math that needs the map (the closest-vehicle
- * visibility check, the route-mode recenter bias) is resolved by the renderer from the live camera.
+ * the actual target from the current render state + the live viewport; the route-mode recenter bias is
+ * resolved by the renderer from the live camera.
  */
 sealed interface CameraCommand {
 
@@ -53,15 +56,6 @@ sealed interface CameraCommand {
 
     /** Set the zoom level (preserving the current center). */
     data class SetZoom(val zoom: Float) : CameraCommand
-
-    /** Fit the route/itinerary polyline bounds with the default padding. */
-    object FitToRoute : CameraCommand
-
-    /** Fit the route/itinerary polyline bounds, padding against the screen dimensions. */
-    object FitToItinerary : CameraCommand
-
-    /** Fit the current region's bounds. */
-    object ZoomToRegion : CameraCommand
 
     /** Step zoom in/out (the zoom FABs). */
     object ZoomIn : CameraCommand

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/FramingIntent.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+/**
+ * A **retained** camera framing — "what the map is currently framing" — as opposed to a transient
+ * [CameraCommand] gesture. A controller sets one via [MapRenderState.frame] and the flavor adapter fits
+ * its imperative map to it; unlike a gesture, the current framing is held (replayed) so a late or
+ * re-created adapter catches up and re-applies it. That replay is what lets the host drop the old
+ * deferral machinery (`pendingFrameCommands`, `mapAttached`/`cameraCommandsSubscribed`, and the
+ * `onCameraCommandsSubscribed` flush): a frame requested before the adapter subscribes — the directions
+ * map composed behind the results sheet the instant a plan completes (#1640), or the region re-zoom
+ * resolved at cold start — is caught by the replay instead of dropped into a no-replay flow.
+ *
+ * Flavor-neutral: like [CameraCommand] it carries *intent*, never a Google/maplibre `CameraUpdate`. The
+ * bounds-fitting cases re-derive their bounds from the live render state + region each time they're
+ * applied (so they are idempotent and safe to re-apply); [Point] carries an explicit target + zoom.
+ */
+sealed interface FramingIntent {
+
+    /** Fit the route polyline bounds with the default padding. */
+    object Route : FramingIntent
+
+    /** Fit the itinerary polyline bounds, padding against the screen dimensions. */
+    object Itinerary : FramingIntent
+
+    /** Fit the current region's bounds. */
+    object Region : FramingIntent
+
+    /** Center on a fixed point at a fixed zoom (the degenerate directions itinerary: start == end). */
+    data class Point(val lat: Double, val lon: Double, val zoom: Float) : FramingIntent
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.android.map.render
 
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -202,15 +203,41 @@ class MapRenderState {
         _projector.value = projector
     }
 
-    // One-shot camera intents a controller dispatches and the flavor adapter applies against its
-    // imperative map (animateCamera/moveCamera). Buffered so the synchronous dispatch never suspends or
-    // drops under a brief burst (e.g. the vehicle poll).
-    private val _cameraCommands = MutableSharedFlow<CameraCommand>(extraBufferCapacity = 16)
+    // Transient one-shot camera gestures a controller dispatches and the flavor adapter applies against
+    // its imperative map (animateCamera/moveCamera). replay=0: a gesture dispatched with no map
+    // subscribed is meant to be discarded — it carries no lasting intent to catch a late subscriber up
+    // on (that's [framingIntent]'s job). Buffered so the synchronous dispatch never suspends or drops
+    // under a brief burst (e.g. the vehicle poll).
+    private val _cameraGestures = MutableSharedFlow<CameraCommand>(extraBufferCapacity = 16)
 
-    val cameraCommands: SharedFlow<CameraCommand> = _cameraCommands.asSharedFlow()
+    val cameraGestures: SharedFlow<CameraCommand> = _cameraGestures.asSharedFlow()
 
-    fun dispatchCamera(command: CameraCommand) {
-        _cameraCommands.tryEmit(command)
+    fun dispatchGesture(command: CameraCommand) {
+        _cameraGestures.tryEmit(command)
+    }
+
+    // The map's retained framing intent (fit route / itinerary / region / a fixed point), or null for no
+    // framing. A replay=1 SharedFlow rather than a StateFlow, for two reasons a plain StateFlow can't
+    // serve at once: (1) a fresh adapter — a config-change or process-restore recompose, or the map
+    // composed behind the directions results sheet (#1640) — replays the current framing and re-applies
+    // it, which is what lets the host drop the pendingFrameCommands / cameraCommandsSubscribed deferral
+    // machinery a replay=0 flow forced; and (2) re-emitting the *same* framing (re-tapping the shown
+    // route to snap back to its extent) still re-fires, whereas a StateFlow would swallow the identical
+    // value as a no-op. Null is emitted to clear framing when the map leaves a framed view, so a stale
+    // route fit isn't re-applied in nearby-stops mode.
+    private val _framingIntent = MutableSharedFlow<FramingIntent?>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    val framingIntent: SharedFlow<FramingIntent?> = _framingIntent.asSharedFlow()
+
+    fun frame(intent: FramingIntent) {
+        _framingIntent.tryEmit(intent)
+    }
+
+    fun clearFraming() {
+        _framingIntent.tryEmit(null)
     }
 
     fun getRoutePolylines(): List<RoutePolyline> = _snapshot.value.routePolylines

--- a/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/region/RegionRepository.kt
@@ -45,8 +45,8 @@ import org.onebusaway.android.util.RegionUtils
  * re-centering) collect [region]/[state]; the resolution action ([refresh]/[choose]) lives here too,
  * folding in the former `RegionStatusRepository`.
  *
- * One process-singleton instance is held on `Application` (mirroring `getGtfsAlerts()`), so every view
- * model shares the same flow; tests substitute a fake. It lives in the neutral `region` package so both
+ * One process-singleton instance is provided by Hilt (like the other app-scoped `@Singleton`s), so every
+ * view model shares the same flow; tests substitute a fake. It lives in the neutral `region` package so both
  * the map and the home UI can depend on it without a backward dependency.
  */
 interface RegionRepository {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/HomeActivity.kt
@@ -24,6 +24,12 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -127,23 +133,28 @@ class HomeActivity : AppCompatActivity() {
             // The welcome tutorial (now the Compose green welcome + map-stop spotlight sequence) is
             // started by HomeScreen off the same showWelcomeTutorial latch — no host effect needed.
             SettingsRehomeEffect(navController)
-            HomeNavHost(
-                navController = navController,
-                home = HomeDestinationDeps(
-                    homeViewModel = viewModel,
-                    mapViewModel = mapViewModel,
-                    surveyViewModel = surveyViewModel,
-                    donationViewModel = donationViewModel,
-                    weatherViewModel = weatherViewModel,
-                    helpViewModel = helpViewModel,
-                    arrivalsViewModelFactory = arrivalsViewModelFactory,
-                    activityActions = activityActions,
-                ),
-            )
-            PaymentWarningDialog(viewModel.paymentWarning, viewModel::dismissPaymentWarning)
-            // The forced region picker, driven reactively off the repository (RegionPickerViewModel). At the
-            // setContent root so its window overlays whatever screen triggered the re-resolve.
-            RegionPickerHost()
+            // Surface Compose testTags as UIAutomator resource-ids app-wide, so screens can be driven
+            // semantically (by tag/text) instead of by coordinate taps in tests + tooling.
+            @OptIn(ExperimentalComposeUiApi::class)
+            Box(Modifier.fillMaxSize().semantics { testTagsAsResourceId = true }) {
+                HomeNavHost(
+                    navController = navController,
+                    home = HomeDestinationDeps(
+                        homeViewModel = viewModel,
+                        mapViewModel = mapViewModel,
+                        surveyViewModel = surveyViewModel,
+                        donationViewModel = donationViewModel,
+                        weatherViewModel = weatherViewModel,
+                        helpViewModel = helpViewModel,
+                        arrivalsViewModelFactory = arrivalsViewModelFactory,
+                        activityActions = activityActions,
+                    ),
+                )
+                PaymentWarningDialog(viewModel.paymentWarning, viewModel::dismissPaymentWarning)
+                // The forced region picker, driven reactively off the repository (RegionPickerViewModel). At the
+                // setContent root so its window overlays whatever screen triggered the re-resolve.
+                RegionPickerHost()
+            }
         }
 
         setupMapState()

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertsRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/widealert/WideAlertsRepository.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import org.onebusaway.android.app.Application
+import org.onebusaway.android.widealerts.GtfsAlerts
 
 /** A region-wide GTFS alert to surface to the user (drives the home wide-alert dialog). */
 data class WideAlert(val title: String, val message: String, val url: String?)
@@ -38,10 +38,12 @@ interface WideAlertsRepository {
  * [kotlinx.coroutines.Dispatchers.IO] is needed because the fetcher already threads itself; the
  * collector's context decides where emissions are observed.
  */
-class DefaultWideAlertsRepository @Inject constructor() : WideAlertsRepository {
+class DefaultWideAlertsRepository @Inject constructor(
+    private val gtfsAlerts: GtfsAlerts,
+) : WideAlertsRepository {
 
     override fun wideAlerts(regionId: String): Flow<WideAlert> = callbackFlow {
-        Application.getGtfsAlerts().fetchAlerts(regionId) { title, message, url ->
+        gtfsAlerts.fetchAlerts(regionId) { title, message, url ->
             trySend(WideAlert(title, message, url))
         }
         // The fetcher exposes no cancellation handle; its background thread is short-lived.

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/GeocodeRepository.kt
@@ -22,36 +22,47 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.region.RegionRepository
+import org.onebusaway.android.util.BuildFlavorUtils
 import org.onebusaway.android.util.LocationUtils
 
 /** Address-autocomplete suggestions for the trip-plan endpoints. */
 interface GeocodeRepository {
-    suspend fun suggest(query: String): Result<List<PlaceItem>>
+    suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>>
 }
 
 /**
- * Pelias-backed geocoding. All four product flavors set `USE_PELIAS_GEOCODING = true`, so the
- * legacy Google-Places intent path is not carried over. Wraps the blocking
- * [LocationUtils.processPeliasGeocoding] on the IO thread and projects [CustomAddress] onto the
- * JVM-pure [PlaceItem] so the ViewModel stays testable.
+ * Address suggestions for the trip-plan endpoints. Prefers Pelias (real autocomplete, with
+ * `transport:public` results flagged as transit), but falls back to the on-device
+ * [android.location.Geocoder] when no Pelias API key is configured — so key-free dev builds still
+ * geocode. Both paths reuse the existing [LocationUtils] geocoders (which handle the region bbox
+ * biasing/filtering); the Geocoder fallback has no typeahead/transit categories, so it's degraded only.
+ * Runs the blocking work on the IO thread and projects onto the JVM-pure [TripEndpoint.Geocoded].
  */
 class DefaultGeocodeRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val regionRepository: RegionRepository,
 ) : GeocodeRepository {
 
-    override suspend fun suggest(query: String): Result<List<PlaceItem>> =
+    override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> =
         withContext(Dispatchers.IO) {
             runCatching {
                 val region = regionRepository.region.value
-                LocationUtils.processPeliasGeocoding(context, region, query).map { it.toPlaceItem() }
+                val addresses = if (BuildFlavorUtils.isPeliasApiKeyDefined()) {
+                    LocationUtils.processPeliasGeocoding(context, region, query)
+                } else {
+                    // No-key fallback: the platform Geocoder, region-biased + filtered — the same helper
+                    // the legacy trip planner already geocodes its endpoint addresses with.
+                    LocationUtils.processGeocoding(context, region, false, query)
+                }
+                addresses.orEmpty().map { it.toGeocoded() }
             }
         }
-
-    private fun CustomAddress.toPlaceItem(): PlaceItem = PlaceItem(
-        displayName = toString(),
-        lat = if (isSet) latitude else null,
-        lon = if (isSet) longitude else null,
-        isTransit = isTransitCategory
-    )
 }
+
+/** Mints the domain [TripEndpoint.Geocoded] from a geocoder [CustomAddress] result (the wire boundary). */
+internal fun CustomAddress.toGeocoded(): TripEndpoint.Geocoded = TripEndpoint.Geocoded(
+    displayName = toString(),
+    lat = if (isSet) latitude else null,
+    lon = if (isSet) longitude else null,
+    isTransit = isTransitCategory
+)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanForm.kt
@@ -15,22 +15,30 @@
  */
 package org.onebusaway.android.ui.tripplan
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +46,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -52,13 +61,29 @@ import org.onebusaway.android.ui.compose.theme.ObaTheme
  * actions. Stateless and driven by [TripPlanFormState]; the date/time/contacts/current-location
  * actions are platform interactions launched by the host.
  */
+/**
+ * Stable UIAutomator/Compose-test handles for the trip-plan form. Surfaced as resource-ids by the
+ * app-wide `testTagsAsResourceId` in HomeActivity, so the form can be driven semantically (focus a
+ * field, tap a suggestion) without coordinate taps. The per-endpoint tags are `<prefix><suffix>`,
+ * e.g. `tripPlanFromField`, `tripPlanToPill`, `tripPlanFromSuggestion`.
+ */
+object TripPlanTestTags {
+    const val FROM_PREFIX = "tripPlanFrom"
+    const val TO_PREFIX = "tripPlanTo"
+    const val FIELD_SUFFIX = "Field"
+    const val PILL_SUFFIX = "Pill"
+    const val SUGGESTION_SUFFIX = "Suggestion"
+}
+
 @Composable
 fun TripPlanForm(
     state: TripPlanFormState,
     onFromQueryChange: (String) -> Unit,
     onToQueryChange: (String) -> Unit,
-    onSelectFrom: (PlaceItem) -> Unit,
-    onSelectTo: (PlaceItem) -> Unit,
+    onSelectFrom: (TripEndpoint.Geocoded) -> Unit,
+    onSelectTo: (TripEndpoint.Geocoded) -> Unit,
+    onClearFrom: () -> Unit,
+    onClearTo: () -> Unit,
     onFromCurrentLocation: () -> Unit,
     onToCurrentLocation: () -> Unit,
     onFromContacts: () -> Unit,
@@ -78,10 +103,12 @@ fun TripPlanForm(
     ) {
         AddressField(
             label = stringResource(R.string.trip_plan_from),
-            query = state.fromQuery,
+            tagPrefix = TripPlanTestTags.FROM_PREFIX,
+            endpoint = state.from,
             suggestions = state.fromSuggestions,
             onQueryChange = onFromQueryChange,
             onSelect = onSelectFrom,
+            onClear = onClearFrom,
             onCurrentLocation = onFromCurrentLocation,
             onContacts = onFromContacts,
             onPickOnMap = onFromPickOnMap
@@ -91,10 +118,12 @@ fun TripPlanForm(
         }
         AddressField(
             label = stringResource(R.string.trip_plan_to),
-            query = state.toQuery,
+            tagPrefix = TripPlanTestTags.TO_PREFIX,
+            endpoint = state.to,
             suggestions = state.toSuggestions,
             onQueryChange = onToQueryChange,
             onSelect = onSelectTo,
+            onClear = onClearTo,
             onCurrentLocation = onToCurrentLocation,
             onContacts = onToContacts,
             onPickOnMap = onToPickOnMap
@@ -122,14 +151,59 @@ fun TripPlanForm(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * One trip-plan endpoint. A still-being-typed [TripEndpoint.FreeText] is an editable autocomplete
+ * field; any resolved kind is shown as a cancellable pill sitting *inside* the same field, where the
+ * text would be — the field is then inoperative (no typing) until the pill's ✕ clears it. The
+ * contacts / current-location / pick-on-map shortcuts stay live in both states, so picking another
+ * input method overrides the current pill.
+ */
 @Composable
 private fun AddressField(
     label: String,
-    query: String,
-    suggestions: List<PlaceItem>,
+    tagPrefix: String,
+    endpoint: TripEndpoint,
+    suggestions: List<TripEndpoint.Geocoded>,
     onQueryChange: (String) -> Unit,
-    onSelect: (PlaceItem) -> Unit,
+    onSelect: (TripEndpoint.Geocoded) -> Unit,
+    onClear: () -> Unit,
+    onCurrentLocation: () -> Unit,
+    onContacts: () -> Unit,
+    onPickOnMap: () -> Unit
+) {
+    when (endpoint) {
+        is TripEndpoint.FreeText -> EditableAddressField(
+            label = label,
+            tagPrefix = tagPrefix,
+            query = endpoint.query,
+            suggestions = suggestions,
+            onQueryChange = onQueryChange,
+            onSelect = onSelect,
+            onCurrentLocation = onCurrentLocation,
+            onContacts = onContacts,
+            onPickOnMap = onPickOnMap
+        )
+        else -> EndpointPillField(
+            label = label,
+            tagPrefix = tagPrefix,
+            endpoint = endpoint,
+            onClear = onClear,
+            onCurrentLocation = onCurrentLocation,
+            onContacts = onContacts,
+            onPickOnMap = onPickOnMap
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditableAddressField(
+    label: String,
+    tagPrefix: String,
+    query: String,
+    suggestions: List<TripEndpoint.Geocoded>,
+    onQueryChange: (String) -> Unit,
+    onSelect: (TripEndpoint.Geocoded) -> Unit,
     onCurrentLocation: () -> Unit,
     onContacts: () -> Unit,
     onPickOnMap: () -> Unit
@@ -146,29 +220,15 @@ private fun AddressField(
             label = { Text(label) },
             singleLine = true,
             trailingIcon = {
-                Row {
-                    IconButton(onClick = onContacts) {
-                        Icon(
-                            painter = painterResource(R.drawable.baseline_import_contacts_24),
-                            contentDescription = stringResource(R.string.trip_plan_from)
-                        )
-                    }
-                    IconButton(onClick = onCurrentLocation) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_my_location),
-                            contentDescription = stringResource(R.string.tripplanner_current_location)
-                        )
-                    }
-                    IconButton(onClick = onPickOnMap) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_action_location_map),
-                            contentDescription = stringResource(R.string.trip_plan_pick_on_map)
-                        )
-                    }
-                }
+                AddressActionIcons(
+                    onContacts = onContacts,
+                    onCurrentLocation = onCurrentLocation,
+                    onPickOnMap = onPickOnMap
+                )
             },
             modifier = Modifier
                 .fillMaxWidth()
+                .testTag(tagPrefix + TripPlanTestTags.FIELD_SUFFIX)
                 .menuAnchor(MenuAnchorType.PrimaryEditable)
         )
         ExposedDropdownMenu(expanded = showMenu, onDismissRequest = { expanded = false }) {
@@ -176,24 +236,136 @@ private fun AddressField(
                 DropdownMenuItem(
                     text = { Text(place.displayName) },
                     leadingIcon = if (place.isTransit) {
-                        {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_bus),
-                                contentDescription = null,
-                                tint = colorResource(R.color.material_gray)
-                            )
-                        }
+                        { BusIcon() }
                     } else {
                         null
                     },
                     onClick = {
                         onSelect(place)
                         expanded = false
-                    }
+                    },
+                    modifier = Modifier.testTag(tagPrefix + TripPlanTestTags.SUGGESTION_SUFFIX)
                 )
             }
         }
     }
+}
+
+/**
+ * A resolved endpoint shown as a pill *inside* an outlined field. There is no editable text — the
+ * pill occupies the field's inner content slot, so the field can't be typed into until ✕ clears it.
+ * The action icons remain in the trailing slot so another input method can replace the pill.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EndpointPillField(
+    label: String,
+    tagPrefix: String,
+    endpoint: TripEndpoint,
+    onClear: () -> Unit,
+    onCurrentLocation: () -> Unit,
+    onContacts: () -> Unit,
+    onPickOnMap: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val endpointText = endpointLabel(endpoint)
+    // Read-only host text field gives the full-width sizing; we ignore its inner text field and drop
+    // the pill into the OutlinedTextField decoration instead, so it renders where the text would be.
+    BasicTextField(
+        value = "",
+        onValueChange = {},
+        readOnly = true,
+        singleLine = true,
+        interactionSource = interactionSource,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(tagPrefix + TripPlanTestTags.PILL_SUFFIX)
+    ) {
+        OutlinedTextFieldDefaults.DecorationBox(
+            value = endpointText, // non-empty so the label floats above the pill
+            innerTextField = {
+                InputChip(
+                    selected = true,
+                    onClick = onClear,
+                    label = {
+                        // Geocoder/contact names can be long; keep the pill to one line inside the
+                        // singleLine field so it doesn't wrap over the trailing clear icon.
+                        Text(endpointText, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    },
+                    leadingIcon = if (endpoint.isTransit) {
+                        { BusIcon() }
+                    } else {
+                        null
+                    },
+                    trailingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = stringResource(R.string.trip_plan_clear_endpoint)
+                        )
+                    }
+                )
+            },
+            enabled = true,
+            singleLine = true,
+            visualTransformation = VisualTransformation.None,
+            interactionSource = interactionSource,
+            label = { Text(label) },
+            trailingIcon = {
+                AddressActionIcons(
+                    onContacts = onContacts,
+                    onCurrentLocation = onCurrentLocation,
+                    onPickOnMap = onPickOnMap
+                )
+            },
+            contentPadding = OutlinedTextFieldDefaults.contentPadding(top = 8.dp, bottom = 8.dp)
+        )
+    }
+}
+
+/** The contacts / current-location / pick-on-map shortcuts shared by both endpoint states. */
+@Composable
+private fun AddressActionIcons(
+    onContacts: () -> Unit,
+    onCurrentLocation: () -> Unit,
+    onPickOnMap: () -> Unit
+) {
+    Row {
+        IconButton(onClick = onContacts) {
+            Icon(
+                painter = painterResource(R.drawable.baseline_import_contacts_24),
+                contentDescription = stringResource(R.string.trip_plan_contacts)
+            )
+        }
+        IconButton(onClick = onCurrentLocation) {
+            Icon(
+                painter = painterResource(R.drawable.ic_my_location),
+                contentDescription = stringResource(R.string.tripplanner_current_location)
+            )
+        }
+        IconButton(onClick = onPickOnMap) {
+            Icon(
+                painter = painterResource(R.drawable.ic_action_location_map),
+                contentDescription = stringResource(R.string.trip_plan_pick_on_map)
+            )
+        }
+    }
+}
+
+/** The user-visible label for a resolved endpoint; fixed kinds resolve a string resource. */
+@Composable
+private fun endpointLabel(endpoint: TripEndpoint): String = endpoint.displayText ?: when (endpoint) {
+    is TripEndpoint.MapPoint -> stringResource(R.string.trip_plan_map_location)
+    // Only the fixed-label kinds (CurrentLocation/MapPoint) have a null displayText.
+    else -> stringResource(R.string.tripplanner_current_location)
+}
+
+@Composable
+private fun BusIcon() {
+    Icon(
+        painter = painterResource(R.drawable.ic_bus),
+        contentDescription = null,
+        tint = colorResource(R.color.material_gray)
+    )
 }
 
 /** Leaving/arriving selector — the Compose equivalent of the legacy Spinner. */
@@ -231,14 +403,15 @@ private fun TripPlanFormPreview() {
     ObaTheme {
         TripPlanForm(
             state = TripPlanFormState(
-                fromQuery = "Current Location",
-                toQuery = "",
+                from = TripEndpoint.CurrentLocation(lat = 47.6, lon = -122.3),
+                to = TripEndpoint.FreeText(""),
                 dateTimeMillis = 0L,
                 dateLabel = "June 10",
                 timeLabel = "3:45 PM"
             ),
             onFromQueryChange = {}, onToQueryChange = {},
             onSelectFrom = {}, onSelectTo = {},
+            onClearFrom = {}, onClearTo = {},
             onFromCurrentLocation = {}, onToCurrentLocation = {},
             onFromContacts = {}, onToContacts = {},
             onFromPickOnMap = {}, onToPickOnMap = {},

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanFormState.kt
@@ -19,20 +19,63 @@ import org.opentripplanner.api.model.Itinerary
 
 /**
  * A JVM-pure projection of a trip-plan endpoint (a [org.onebusaway.android.directions.util.CustomAddress]),
- * so the ViewModel and its tests don't depend on `android.location.Address`. [lat]/[lon] are null
- * for endpoints without coordinates (e.g. a contacts pick); the repository encodes those as a raw
- * string for the OTP server to geocode.
+ * so the ViewModel and its tests don't depend on `android.location.Address`. Modeled as a sealed type
+ * so the form can render each kind appropriately: only [FreeText] is an editable field; every resolved
+ * kind ([Geocoded]/[AddressBook]/[CurrentLocation]/[MapPoint]) is shown as a cancellable pill.
+ *
+ * [lat]/[lon] are null for endpoints without coordinates (e.g. a contacts pick or a still-typed query);
+ * the repository encodes those as a raw string for the OTP server to geocode.
  */
-data class PlaceItem(
-    val displayName: String,
-    val lat: Double? = null,
-    val lon: Double? = null,
-    /** The geocoder flagged this as a public-transit location (drives the suggestion icon). */
-    val isTransit: Boolean = false,
-    val isCurrentLocation: Boolean = false
-) {
+sealed interface TripEndpoint {
+    val lat: Double?
+    val lon: Double?
+
     /** Mirrors CustomAddress.isSet(): a usable endpoint must have coordinates. */
     val hasCoordinates: Boolean get() = lat != null && lon != null
+
+    /** The geocoder flagged this as a public-transit location (drives the pill/suggestion icon). */
+    val isTransit: Boolean get() = false
+
+    /**
+     * The text this endpoint carries itself (a typed query or a resolved place name), or null for the
+     * fixed-label kinds ([CurrentLocation]/[MapPoint]) whose label is a string resource resolved by the
+     * Android layer. Keeps the shared part of the endpoint→label mapping in one place instead of
+     * duplicated across each call site's `when`.
+     */
+    val displayText: String? get() = when (this) {
+        is FreeText -> query
+        is Geocoded -> displayName
+        is AddressBook -> displayName
+        is CurrentLocation, is MapPoint -> null
+    }
+
+    /** Empty or still-being-typed text — the only editable, non-pill state. Never has coordinates. */
+    data class FreeText(val query: String = "") : TripEndpoint {
+        override val lat: Double? get() = null
+        override val lon: Double? get() = null
+    }
+
+    /** A geocoder (Pelias) autocomplete pick. */
+    data class Geocoded(
+        val displayName: String,
+        override val lat: Double?,
+        override val lon: Double?,
+        /** The geocoder flagged this as a public-transit location (drives the pill/suggestion icon). */
+        override val isTransit: Boolean = false,
+    ) : TripEndpoint
+
+    /** An address-book (contacts) pick; may still need server-side geocoding (null coordinates). */
+    data class AddressBook(
+        val displayName: String,
+        override val lat: Double?,
+        override val lon: Double?,
+    ) : TripEndpoint
+
+    /** The device's current location. Its label is a fixed string resolved by the UI. */
+    data class CurrentLocation(override val lat: Double?, override val lon: Double?) : TripEndpoint
+
+    /** A point chosen on the map. Its label is a fixed string resolved by the UI. */
+    data class MapPoint(override val lat: Double, override val lon: Double) : TripEndpoint
 }
 
 /** The advanced trip options, persisted in preferences by the host. */
@@ -45,8 +88,8 @@ data class AdvancedSettings(
 
 /** A fully-specified plan request handed to [TripPlanRepository]. */
 data class TripPlanParams(
-    val from: PlaceItem,
-    val to: PlaceItem,
+    val from: TripEndpoint,
+    val to: TripEndpoint,
     val dateTimeMillis: Long,
     val arriving: Boolean,
     val modeId: Int,
@@ -57,12 +100,10 @@ data class TripPlanParams(
 
 /** The trip-plan form (origin/destination, when, and the advanced options). */
 data class TripPlanFormState(
-    val from: PlaceItem? = null,
-    val to: PlaceItem? = null,
-    val fromQuery: String = "",
-    val toQuery: String = "",
-    val fromSuggestions: List<PlaceItem> = emptyList(),
-    val toSuggestions: List<PlaceItem> = emptyList(),
+    val from: TripEndpoint = TripEndpoint.FreeText(),
+    val to: TripEndpoint = TripEndpoint.FreeText(),
+    val fromSuggestions: List<TripEndpoint.Geocoded> = emptyList(),
+    val toSuggestions: List<TripEndpoint.Geocoded> = emptyList(),
     val dateTimeMillis: Long = 0L,
     val arriving: Boolean = false,
     val dateLabel: String = "",
@@ -74,7 +115,7 @@ data class TripPlanFormState(
 ) {
     /** Mirrors TripRequestBuilder.ready(): both endpoints must resolve to coordinates. */
     val canSubmit: Boolean
-        get() = from?.hasCoordinates == true && to?.hasCoordinates == true
+        get() = from.hasCoordinates && to.hasCoordinates
 
     /** The current advanced options, for persistence by the host. */
     val advancedSettings: AdvancedSettings
@@ -82,8 +123,8 @@ data class TripPlanFormState(
 
     /** Builds the plan request; only call when [canSubmit] is true. */
     fun toParams(): TripPlanParams = TripPlanParams(
-        from = from!!,
-        to = to!!,
+        from = from,
+        to = to,
         dateTimeMillis = dateTimeMillis,
         arriving = arriving,
         modeId = modeId,

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanRepository.kt
@@ -178,14 +178,23 @@ class DefaultTripPlanRepository @Inject constructor(
         return parsed
     }
 
-    private fun PlaceItem.toCustomAddress(): CustomAddress {
+    private fun TripEndpoint.toCustomAddress(): CustomAddress {
         val address = CustomAddress.getEmptyAddress()
+        val lat = lat
+        val lon = lon
         if (lat != null && lon != null) {
             address.latitude = lat
             address.longitude = lon
         }
-        address.setAddressLine(0, displayName)
+        address.setAddressLine(0, addressLine())
         return address
+    }
+
+    /** The string the OTP server geocodes (or just labels the request); fixed kinds resolve a resource. */
+    private fun TripEndpoint.addressLine(): String = displayText ?: when (this) {
+        is TripEndpoint.MapPoint -> context.getString(R.string.trip_plan_map_location)
+        // Only the fixed-label kinds (CurrentLocation/MapPoint) have a null displayText.
+        else -> context.getString(R.string.tripplanner_current_location)
     }
 
     private fun errorMessage(errorCode: Int): String = when (errorCode) {

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanScreen.kt
@@ -79,7 +79,6 @@ import org.onebusaway.android.app.di.AnalyticsEntryPoint
 import org.onebusaway.android.app.di.LocationEntryPoint
 import org.onebusaway.android.app.di.RegionEntryPoint
 import org.onebusaway.android.directions.util.ConversionUtils
-import org.onebusaway.android.directions.util.CustomAddress
 import org.onebusaway.android.directions.util.OTPConstants
 import org.onebusaway.android.directions.util.TripRequestBuilder
 import org.onebusaway.android.analytics.PlausibleAnalytics
@@ -117,17 +116,17 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
 
     // -- Contacts pick: a launcher + the endpoint a pending pick should populate. A contacts pick
     // doesn't dispose this composable, so a plain remember (not rememberSaveable) suffices.
-    var contactsTarget by remember { mutableStateOf<((PlaceItem) -> Unit)?>(null) }
+    var contactsTarget by remember { mutableStateOf<((TripEndpoint) -> Unit)?>(null) }
     val contactsLauncher = rememberLauncherForActivityResult(StartActivityForResult()) { result ->
         val uri = result.data?.data
         if (uri != null) {
             formattedAddress(activity, uri)?.let { address ->
-                contactsTarget?.invoke(PlaceItem(displayName = address))
+                contactsTarget?.invoke(TripEndpoint.AddressBook(address, lat = null, lon = null))
             }
         }
         contactsTarget = null
     }
-    val launchContacts: ((PlaceItem) -> Unit) -> Unit = { target ->
+    val launchContacts: ((TripEndpoint) -> Unit) -> Unit = { target ->
         contactsTarget = target
         contactsLauncher.launch(
             Intent(Intent.ACTION_PICK)
@@ -140,7 +139,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
     // MUST be rememberSaveable: navigating to the picker disposes this composable, and a lambda can't
     // be saved across that — so we save which endpoint to populate, not the setter.
     var mapPickTarget by rememberSaveable { mutableStateOf<String?>(null) }
-    val launchMapPicker: (String, PlaceItem?) -> Unit = { endpoint, initial ->
+    val launchMapPicker: (String, TripEndpoint?) -> Unit = { endpoint, initial ->
         val center = if (initial?.hasCoordinates == true) {
             LocationUtils.makeLocation(initial.lat!!, initial.lon!!)
         } else {
@@ -151,7 +150,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
             NavRoutes.tripPlanPickLocation(center?.latitude, center?.longitude)
         )
     }
-    // When the picker hands a result back to this entry's SavedStateHandle, build the PlaceItem and
+    // When the picker hands a result back to this entry's SavedStateHandle, build the endpoint and
     // dispatch it to the saved endpoint, then clear the keys + the target.
     val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle
     LaunchedEffect(savedStateHandle, mapPickTarget) {
@@ -159,11 +158,7 @@ fun TripPlanDestination(navController: NavHostController, onBack: () -> Unit) {
         val lat = handle.get<Double>(NavRoutes.RESULT_PICK_LAT)
         val lon = handle.get<Double>(NavRoutes.RESULT_PICK_LON)
         if (lat != null && lon != null) {
-            val place = PlaceItem(
-                displayName = activity.getString(R.string.trip_plan_map_location),
-                lat = lat,
-                lon = lon
-            )
+            val place = TripEndpoint.MapPoint(lat = lat, lon = lon)
             when (mapPickTarget) {
                 "from" -> viewModel.setFrom(place)
                 "to" -> viewModel.setTo(place)
@@ -326,6 +321,8 @@ fun TripPlanRoute(
                         onToQueryChange = viewModel::onToQueryChange,
                         onSelectFrom = viewModel::setFrom,
                         onSelectTo = viewModel::setTo,
+                        onClearFrom = viewModel::clearFrom,
+                        onClearTo = viewModel::clearTo,
                         onFromCurrentLocation = onFromCurrentLocation,
                         onToCurrentLocation = onToCurrentLocation,
                         onFromContacts = onFromContacts,
@@ -415,21 +412,17 @@ private fun pickTime(activity: AppCompatActivity, viewModel: TripPlanViewModel) 
 
 private fun setCurrentLocation(
     activity: AppCompatActivity,
-    target: (PlaceItem) -> Unit
+    target: (TripEndpoint) -> Unit
 ) {
     val location = LocationEntryPoint.get(activity.applicationContext).lastKnownLocation()
     if (location == null) {
         Toast.makeText(activity, activity.getString(R.string.no_location_permission), Toast.LENGTH_SHORT)
             .show()
+        // Without a location this would be a coordinate-less, non-submittable pill that also drops any
+        // existing result — bail after the toast instead.
+        return
     }
-    target(
-        PlaceItem(
-            displayName = activity.getString(R.string.tripplanner_current_location),
-            lat = location?.latitude,
-            lon = location?.longitude,
-            isCurrentLocation = true
-        )
-    )
+    target(TripEndpoint.CurrentLocation(lat = location.latitude, lon = location.longitude))
 }
 
 private fun formattedAddress(
@@ -630,17 +623,11 @@ private fun maybeRestoreFromIntent(
 
     val builder = TripRequestBuilder.initFromBundleSimple(context, extras)
     viewModel.restoreFrom(
-        from = builder.from?.toPlaceItem(),
-        to = builder.to?.toPlaceItem(),
+        from = builder.from?.toGeocoded(),
+        to = builder.to?.toGeocoded(),
         dateTimeMillis = builder.dateTime?.time ?: System.currentTimeMillis(),
         arriving = builder.arriveBy,
         itineraries = itineraries
     )
     return Intent()
 }
-
-private fun CustomAddress.toPlaceItem(): PlaceItem = PlaceItem(
-    displayName = toString(),
-    lat = if (isSet) latitude else null,
-    lon = if (isSet) longitude else null
-)

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/tripplan/TripPlanViewModel.kt
@@ -24,6 +24,7 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -31,8 +32,8 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import org.onebusaway.android.util.TimeProvider
 import org.opentripplanner.api.model.Itinerary
 
@@ -74,6 +75,15 @@ class TripPlanViewModel @Inject constructor(
     private val fromQueries = MutableStateFlow("")
     private val toQueries = MutableStateFlow("")
 
+    // Plan submissions, driven reactively. Each user action that can change the plan sends its params
+    // (or null when the form isn't submittable) here; the collector below [mapLatest]-cancels the plan
+    // in flight as soon as the next input arrives, so a slow plan that outlives its edit can't publish a
+    // stale result — the same latest-wins pattern as the suggestion pipelines, no request bookkeeping.
+    // A CONFLATED channel (not a SharedFlow) keeps only the latest input and retains it until the
+    // collector is ready, so an input sent before collection starts isn't lost. Deliberately NOT derived
+    // from [_formState]: restoreFrom injects a result without re-planning.
+    private val planInputs = Channel<TripPlanParams?>(Channel.CONFLATED)
+
     init {
         fromQueries
             .debounce(SUGGEST_DEBOUNCE_MS)
@@ -85,42 +95,72 @@ class TripPlanViewModel @Inject constructor(
             .mapLatest(::suggestionsFor)
             .onEach { suggestions -> _formState.update { it.copy(toSuggestions = suggestions) } }
             .launchIn(viewModelScope)
+        planInputs.receiveAsFlow()
+            .mapLatest { params ->
+                if (params == null) {
+                    // Form no longer submittable: drop a surfaced result (Success/Loading) back to Idle.
+                    if (_planState.value !is PlanResult.Idle) _planState.value = PlanResult.Idle
+                } else {
+                    _planState.value = PlanResult.Loading
+                    planRepository.plan(params).fold(
+                        onSuccess = { _planState.value = PlanResult.Success(it) },
+                        onFailure = { _planState.value = PlanResult.Error(it.message.orEmpty()) }
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
     }
 
-    private suspend fun suggestionsFor(query: String): List<PlaceItem> =
+    private suspend fun suggestionsFor(query: String): List<TripEndpoint.Geocoded> =
         if (query.isBlank()) emptyList() else geocode.suggest(query).getOrDefault(emptyList())
 
     fun onFromQueryChange(query: String) {
-        _formState.update { it.copy(fromQuery = query) }
+        _formState.update { it.copy(from = TripEndpoint.FreeText(query)) }
         fromQueries.value = query
+        // Editing over a resolved endpoint makes the form non-submittable — drop any stale route too.
+        replanOrClearResult()
     }
 
     fun onToQueryChange(query: String) {
-        _formState.update { it.copy(toQuery = query) }
+        _formState.update { it.copy(to = TripEndpoint.FreeText(query)) }
         toQueries.value = query
+        replanOrClearResult()
     }
 
-    /** Sets the origin (from a suggestion, current location, or contacts) and re-plans if ready. */
-    fun setFrom(place: PlaceItem) {
-        _formState.update { it.copy(from = place, fromQuery = place.displayName, fromSuggestions = emptyList()) }
-        autoSubmitIfReady()
+    /** Sets the origin (from a suggestion, current location, contacts, or map) and re-plans if ready. */
+    fun setFrom(endpoint: TripEndpoint) {
+        _formState.update { it.copy(from = endpoint, fromSuggestions = emptyList()) }
+        replanOrClearResult()
     }
 
-    fun setTo(place: PlaceItem) {
-        _formState.update { it.copy(to = place, toQuery = place.displayName, toSuggestions = emptyList()) }
-        autoSubmitIfReady()
+    fun setTo(endpoint: TripEndpoint) {
+        _formState.update { it.copy(to = endpoint, toSuggestions = emptyList()) }
+        replanOrClearResult()
+    }
+
+    /** Clears the origin back to an empty editable field (the pill's ✕), dropping any stale result. */
+    fun clearFrom() {
+        _formState.update { it.copy(from = TripEndpoint.FreeText(), fromSuggestions = emptyList()) }
+        fromQueries.value = ""
+        replanOrClearResult()
+    }
+
+    fun clearTo() {
+        _formState.update { it.copy(to = TripEndpoint.FreeText(), toSuggestions = emptyList()) }
+        toQueries.value = ""
+        replanOrClearResult()
     }
 
     fun setDateTime(millis: Long) {
         _formState.update {
             it.copy(dateTimeMillis = millis, dateLabel = formatDate(millis), timeLabel = formatTime(millis))
         }
-        autoSubmitIfReady()
+        replanOrClearResult()
     }
 
     fun setArriving(arriving: Boolean) {
         _formState.update { it.copy(arriving = arriving) }
-        autoSubmitIfReady()
+        replanOrClearResult()
     }
 
     fun applyAdvancedSettings(settings: AdvancedSettings) {
@@ -132,31 +172,17 @@ class TripPlanViewModel @Inject constructor(
                 wheelchair = settings.wheelchair
             )
         }
-        autoSubmitIfReady()
+        replanOrClearResult()
     }
 
     fun reverseTrip() {
         _formState.update {
             it.copy(
                 from = it.to, to = it.from,
-                fromQuery = it.toQuery, toQuery = it.fromQuery,
                 fromSuggestions = emptyList(), toSuggestions = emptyList()
             )
         }
-        autoSubmitIfReady()
-    }
-
-    /** Submits the plan if both endpoints resolve to coordinates. */
-    fun planTrip() {
-        val form = _formState.value
-        if (!form.canSubmit) return
-        _planState.value = PlanResult.Loading
-        viewModelScope.launch {
-            planRepository.plan(form.toParams()).fold(
-                onSuccess = { _planState.value = PlanResult.Success(it) },
-                onFailure = { _planState.value = PlanResult.Error(it.message.orEmpty()) }
-            )
-        }
+        replanOrClearResult()
     }
 
     /** Clears a surfaced error after the host shows it. */
@@ -169,8 +195,8 @@ class TripPlanViewModel @Inject constructor(
      * without re-planning, so the user lands back on the trip they were watching.
      */
     fun restoreFrom(
-        from: PlaceItem?,
-        to: PlaceItem?,
+        from: TripEndpoint?,
+        to: TripEndpoint?,
         dateTimeMillis: Long,
         arriving: Boolean,
         itineraries: List<Itinerary>
@@ -179,8 +205,6 @@ class TripPlanViewModel @Inject constructor(
             it.copy(
                 from = from ?: it.from,
                 to = to ?: it.to,
-                fromQuery = from?.displayName ?: it.fromQuery,
-                toQuery = to?.displayName ?: it.toQuery,
                 dateTimeMillis = dateTimeMillis,
                 dateLabel = formatDate(dateTimeMillis),
                 timeLabel = formatTime(dateTimeMillis),
@@ -192,8 +216,15 @@ class TripPlanViewModel @Inject constructor(
         }
     }
 
-    private fun autoSubmitIfReady() {
-        if (_formState.value.canSubmit) planTrip()
+    /**
+     * Called after any form change: hand the latest plan inputs to the [planInputs] pipeline, which
+     * re-plans when both endpoints resolve and otherwise drops a stale result back to [PlanResult.Idle]
+     * so a changed or cleared endpoint can't leave an old route on screen (the results sheet keys off
+     * [PlanResult.Success]). Emitting supersedes any in-flight plan via the collector's [mapLatest].
+     */
+    private fun replanOrClearResult() {
+        val form = _formState.value
+        planInputs.trySend(if (form.canSubmit) form.toParams() else null)
     }
 
     private fun formatDate(millis: Long): String =

--- a/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/widealerts/GtfsAlerts.java
@@ -15,16 +15,23 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import dagger.hilt.android.qualifiers.ApplicationContext;
+
 /**
  * Fetches GTFS alerts and processes them.
  */
+@Singleton
 public class GtfsAlerts {
 
     private static final String TAG = "GtfsAlerts";
     private static final Set<String> fetchedRegions = new HashSet<>();
     private final Context mContext;
 
-    public GtfsAlerts(Context context) {
+    @Inject
+    public GtfsAlerts(@ApplicationContext Context context) {
         mContext = context;
     }
 

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -886,6 +886,8 @@
     <string name="trip_plan_pick_on_map">Pick location on map</string>
     <string name="trip_plan_use_this_location">Use this location</string>
     <string name="trip_plan_map_location">Selected location</string>
+    <string name="trip_plan_clear_endpoint">Clear</string>
+    <string name="trip_plan_contacts">Choose from contacts</string>
 
 
     <string name="trip_plan_list_view">List View</string>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreCameraCommands.kt
@@ -23,6 +23,7 @@ import org.maplibre.android.maps.MapLibreMap
 import org.onebusaway.android.app.Application
 import org.onebusaway.android.map.maplibre.MapHelpMapLibre
 import org.onebusaway.android.map.render.CameraCommand
+import org.onebusaway.android.map.render.FramingIntent
 import org.onebusaway.android.map.render.MapRenderState
 import kotlin.math.abs
 
@@ -30,17 +31,14 @@ import kotlin.math.abs
 private const val CAMERA_DEFAULT_ZOOM = 16.0
 
 /**
- * Applies one [CameraCommand] to the maplibre [MapLibreMap] — the declarative counterpart of the
- * Google adapter's `applyCameraCommand`. It's a faithful port of the old `MapLibreMapHost` camera
- * methods (which called `mMap.animateCamera/moveCamera` directly); now the host dispatches intents and
- * the adapter applies them here. maplibre's camera calls are fire-and-forget (not suspending), so this
- * isn't a suspend function. Bounds-fitting reads the route shape from [renderState]; the route-header
- * recenter bias reads the live viewport from [map].
- *
- * As on the old host, route/itinerary/closest-vehicle framing all just frame the route shape — the
- * screen-dimension padding and closest-vehicle inclusion were Google-only refinements.
+ * Applies one transient [CameraCommand] gesture to the maplibre [MapLibreMap] — the declarative
+ * counterpart of the Google adapter's `applyCameraCommand`. It's a faithful port of the old
+ * `MapLibreMapHost` camera methods (which called `mMap.animateCamera/moveCamera` directly); now the host
+ * dispatches gestures and the adapter applies them here. maplibre's camera calls are fire-and-forget
+ * (not suspending), so this isn't a suspend function. The route-header recenter bias reads the live
+ * viewport from [map]. Retained framing is applied by [applyFramingIntent].
  */
-fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap, renderState: MapRenderState) {
+fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap) {
     when (cmd) {
         is CameraCommand.Recenter -> {
             val cp = map.cameraPosition
@@ -75,23 +73,37 @@ fun applyCameraCommand(cmd: CameraCommand, map: MapLibreMap, renderState: MapRen
 
         is CameraCommand.SetZoom -> map.moveCamera(CameraUpdateFactory.zoomTo(cmd.zoom.toDouble()))
 
-        CameraCommand.FitToRoute,
-        CameraCommand.FitToItinerary -> {
-            val bounds = routePolylineBounds(renderState) ?: return
-            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0))
-        }
-
-        CameraCommand.ZoomToRegion -> {
-            val region = Application.get().currentRegion ?: return
-            map.animateCamera(CameraUpdateFactory.newLatLngBounds(MapHelpMapLibre.getRegionBounds(region), 0))
-        }
-
         CameraCommand.ZoomIn -> map.animateCamera(CameraUpdateFactory.zoomIn())
 
         CameraCommand.ZoomOut -> map.animateCamera(CameraUpdateFactory.zoomOut())
 
         // maplibre has no map-type tilt reset, so its host never dispatches this.
         CameraCommand.ResetTilt -> Unit
+    }
+}
+
+/**
+ * Applies the map's retained [FramingIntent] to the maplibre [MapLibreMap] — the counterpart of the
+ * Google adapter's `applyFramingIntent`. As on the old host, route/itinerary framing both just frame the
+ * route shape (the screen-dimension padding was a Google-only refinement); the bounds are re-read from
+ * [renderState]/the region live, so it's safe to re-apply when a re-created adapter replays the framing.
+ */
+fun applyFramingIntent(intent: FramingIntent, map: MapLibreMap, renderState: MapRenderState) {
+    when (intent) {
+        FramingIntent.Route,
+        FramingIntent.Itinerary -> {
+            val bounds = routePolylineBounds(renderState) ?: return
+            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0))
+        }
+
+        FramingIntent.Region -> {
+            val region = Application.get().currentRegion ?: return
+            map.animateCamera(CameraUpdateFactory.newLatLngBounds(MapHelpMapLibre.getRegionBounds(region), 0))
+        }
+
+        is FramingIntent.Point -> map.moveCamera(
+            CameraUpdateFactory.newLatLngZoom(LatLng(intent.lat, intent.lon), intent.zoom.toDouble())
+        )
     }
 }
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -62,7 +62,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.filterNotNull
 import kotlin.math.abs
 
 private const val STYLE_URL_LIGHT = "https://tiles.openfreemap.org/styles/liberty"
@@ -76,8 +76,8 @@ private const val FRAME_INTERVAL_NANOS = 8_333_333L
  * [AndroidView] (there is no maplibre-compose), bridging the MapView's imperative lifecycle to Compose
  * via a [LifecycleEventObserver], and drives the [MapHost]: it sets the style, builds the
  * [MapLibreRenderer] and re-renders on every render-state change, wires map/marker/info-window clicks
- * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the dispatched camera intents
- * from the render state's cameraCommands, and enables the location blue dot from the host's
+ * to [callbacks], reports camera idles to [MapHost.onCameraIdle], applies the render state's camera
+ * gestures + retained framing intent, and enables the location blue dot from the host's
  * permission-derived flag. There is no imperative host.
  *
  * Lifecycle note: `addObserver` on an already-STARTED/RESUMED lifecycle synchronously dispatches the
@@ -211,23 +211,18 @@ class MapLibreComposeAdapter : ObaComposeMapAdapter {
             }
         }
 
-        // Declarative camera: apply the dispatched camera intents to the map once ready, and tell the host
-        // the adapter is subscribed (so a deferred route re-frame can dispatch now rather than waiting).
+        // Declarative camera. Transient gestures apply as they arrive (dropped if none pending when the
+        // map wasn't subscribed); the retained framing intent is replayed to this collector when the map
+        // (re)composes, so a fit requested before the adapter subscribed — the directions map composed
+        // behind the results sheet (#1640), or a re-tap of the shown route — is re-applied here rather
+        // than deferred through a host flag; null clears it (no framing to apply).
         val map = mapLibreMap
         if (map != null) {
-            DisposableEffect(map) {
-                host.setMapAttached(true)
-                onDispose { host.setMapAttached(false) }
+            LaunchedEffect(map) {
+                renderState.cameraGestures.collect { command -> applyCameraCommand(command, map) }
             }
             LaunchedEffect(map) {
-                renderState.cameraCommands
-                    // Flush any frame deferred while the map was detached the moment this collector is
-                    // registered — emissions in onSubscription reach this collector, so a deferred fit
-                    // isn't dropped by the no-replay flow if the first camera-idle beats us (#1640).
-                    .onSubscription { host.onCameraCommandsSubscribed() }
-                    .collect { command ->
-                        applyCameraCommand(command, map, renderState)
-                    }
+                renderState.framingIntent.filterNotNull().collect { applyFramingIntent(it, map, renderState) }
             }
         }
 

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateFramingTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/MapRenderStateFramingTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The behavioral contract the framing/gesture split (#1648) depends on: retained framing replays to a
+ * late subscriber (so a fit requested before the adapter subscribes — the directions map behind the
+ * results sheet, a re-created map — isn't dropped), re-fires on an identical value (unlike a StateFlow),
+ * and can be cleared; transient gestures are dropped when nothing is listening.
+ */
+class MapRenderStateFramingTest {
+
+    @Test
+    fun `framing replays the current intent to a late subscriber`() = runTest {
+        val state = MapRenderState()
+        // Frame before anyone subscribes — the old replay=0 flow would drop this.
+        state.frame(FramingIntent.Route)
+
+        assertEquals(FramingIntent.Route, state.framingIntent.first())
+    }
+
+    @Test
+    fun `re-emitting the same framing re-fires (a StateFlow would swallow it)`() = runTest {
+        val state = MapRenderState()
+        val seen = mutableListOf<FramingIntent?>()
+        // UnconfinedTestDispatcher subscribes eagerly, so the collector is active before we emit.
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            state.framingIntent.toList(seen)
+        }
+
+        state.frame(FramingIntent.Route)
+        state.frame(FramingIntent.Route) // identical — must still be delivered
+
+        assertEquals(listOf(FramingIntent.Route, FramingIntent.Route), seen)
+        job.cancel()
+    }
+
+    @Test
+    fun `clearFraming replays null so a stale fit is not re-applied`() = runTest {
+        val state = MapRenderState()
+        state.frame(FramingIntent.Region)
+        state.clearFraming()
+
+        assertNull(state.framingIntent.first())
+    }
+
+    @Test
+    fun `a gesture dispatched with no subscriber is dropped`() = runTest {
+        val state = MapRenderState()
+        // No collector yet: this gesture has nowhere to go and must not be replayed.
+        state.dispatchGesture(CameraCommand.ZoomIn)
+
+        val seen = mutableListOf<CameraCommand>()
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            state.cameraGestures.toList(seen)
+        }
+        state.dispatchGesture(CameraCommand.ZoomOut)
+
+        assertEquals(listOf(CameraCommand.ZoomOut), seen)
+        job.cancel()
+    }
+}

--- a/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/ui/tripplan/TripPlanViewModelTest.kt
@@ -16,6 +16,7 @@
 package org.onebusaway.android.ui.tripplan
 
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -36,12 +37,12 @@ class TripPlanViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val settings = AdvancedSettings(modeId = 4, maxWalkMeters = 1600.0, optimizeTransfers = true, wheelchair = false)
-    private val origin = PlaceItem("Origin", lat = 47.6, lon = -122.3)
-    private val destination = PlaceItem("Destination", lat = 47.7, lon = -122.2)
+    private val origin = TripEndpoint.Geocoded("Origin", lat = 47.6, lon = -122.3)
+    private val destination = TripEndpoint.Geocoded("Destination", lat = 47.7, lon = -122.2)
 
-    private class FakeGeocodeRepository(var result: Result<List<PlaceItem>>) : GeocodeRepository {
+    private class FakeGeocodeRepository(var result: Result<List<TripEndpoint.Geocoded>>) : GeocodeRepository {
         var lastQuery: String? = null
-        override suspend fun suggest(query: String): Result<List<PlaceItem>> {
+        override suspend fun suggest(query: String): Result<List<TripEndpoint.Geocoded>> {
             lastQuery = query
             return result
         }
@@ -58,6 +59,18 @@ class TripPlanViewModelTest {
             result.getOrDefault(emptyList())
     }
 
+    /** A plan repository whose call suspends until [gate] is completed, to exercise the in-flight race. */
+    private class GatedTripPlanRepository : TripPlanRepository {
+        val gate = CompletableDeferred<Result<List<Itinerary>>>()
+        var calls = 0
+        override suspend fun plan(params: TripPlanParams): Result<List<Itinerary>> {
+            calls++
+            return gate.await()
+        }
+
+        override fun planBlocking(builder: TripRequestBuilder): List<Itinerary> = emptyList()
+    }
+
     private inner class FakeAdvancedSettingsRepository : AdvancedSettingsRepository {
         override fun load() = settings
     }
@@ -66,6 +79,12 @@ class TripPlanViewModelTest {
         geocode: GeocodeRepository = FakeGeocodeRepository(Result.success(emptyList())),
         plan: TripPlanRepository = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
     ) = TripPlanViewModel(geocode, plan, TimeProvider { 0L }, FakeAdvancedSettingsRepository())
+
+    /** Sets both resolved endpoints (which auto-submits a plan once both have coordinates). */
+    private fun setBothEndpoints(vm: TripPlanViewModel) {
+        vm.setFrom(origin)
+        vm.setTo(destination)
+    }
 
     @Test
     fun `initial state carries the injected settings and cannot submit`() = runTest {
@@ -89,6 +108,42 @@ class TripPlanViewModelTest {
     }
 
     @Test
+    fun `a query change makes the origin a FreeText endpoint`() = runTest {
+        val vm = viewModel()
+        vm.onFromQueryChange("downtown")
+        assertEquals(TripEndpoint.FreeText("downtown"), vm.formState.value.from)
+        assertFalse(vm.formState.value.canSubmit)
+    }
+
+    @Test
+    fun `selecting a geocoded suggestion stores the resolved endpoint`() = runTest {
+        val vm = viewModel()
+        vm.onFromQueryChange("orig")
+        advanceUntilIdle()
+        vm.setFrom(origin)
+        advanceUntilIdle()
+        val state = vm.formState.value
+        assertEquals(origin, state.from)
+        assertTrue(state.fromSuggestions.isEmpty())
+    }
+
+    @Test
+    fun `clearFrom resets the origin to empty FreeText and does not submit`() = runTest {
+        val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
+        val vm = viewModel(plan = plan)
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertEquals(1, plan.calls)
+
+        vm.clearFrom()
+        advanceUntilIdle()
+        val state = vm.formState.value
+        assertEquals(TripEndpoint.FreeText(), state.from)
+        assertFalse(state.canSubmit)
+        assertEquals(1, plan.calls) // clearing must not re-plan
+    }
+
+    @Test
     fun `setting both endpoints with coordinates auto-submits the plan`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
         val vm = viewModel(plan = plan)
@@ -105,12 +160,72 @@ class TripPlanViewModelTest {
     }
 
     @Test
+    fun `clearing an endpoint after a successful plan drops the stale result`() = runTest {
+        val vm = viewModel()
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertTrue(vm.planState.value is PlanResult.Success)
+
+        vm.clearTo()
+        advanceUntilIdle()
+        assertFalse(vm.formState.value.canSubmit)
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
+    fun `typing over a resolved endpoint drops the stale result`() = runTest {
+        val vm = viewModel()
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        assertTrue(vm.planState.value is PlanResult.Success)
+
+        vm.onFromQueryChange("typing over the pill")
+        advanceUntilIdle()
+        assertFalse(vm.formState.value.canSubmit)
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
+    fun `a plan finishing after the form is cleared cannot surface a stale route`() = runTest {
+        val plan = GatedTripPlanRepository()
+        val vm = viewModel(plan = plan)
+        setBothEndpoints(vm) // canSubmit -> a plan launches and suspends on the gate
+        advanceUntilIdle()
+        assertEquals(PlanResult.Loading, vm.planState.value)
+
+        vm.clearTo() // form no longer submittable: invalidates the in-flight plan
+        advanceUntilIdle()
+        assertEquals(PlanResult.Idle, vm.planState.value)
+
+        plan.gate.complete(Result.success(listOf(Itinerary()))) // late completion of the stale plan
+        advanceUntilIdle()
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
+    fun `changing one endpoint while the other is unset does not surface a route`() = runTest {
+        val vm = viewModel()
+        // Seed a stale success, then reset both endpoints to empty as a fresh start.
+        setBothEndpoints(vm)
+        advanceUntilIdle()
+        vm.clearFrom()
+        vm.clearTo()
+        advanceUntilIdle()
+
+        // Selecting just one endpoint must not bring back the old route.
+        vm.setFrom(origin)
+        advanceUntilIdle()
+        assertFalse(vm.formState.value.canSubmit)
+        assertEquals(PlanResult.Idle, vm.planState.value)
+    }
+
+    @Test
     fun `an endpoint without coordinates does not enable submit`() = runTest {
         val plan = FakeTripPlanRepository(Result.success(listOf(Itinerary())))
         val vm = viewModel(plan = plan)
 
-        vm.setFrom(PlaceItem("Contact A", lat = null, lon = null))
-        vm.setTo(PlaceItem("Contact B", lat = null, lon = null))
+        vm.setFrom(TripEndpoint.AddressBook("Contact A", lat = null, lon = null))
+        vm.setTo(TripEndpoint.AddressBook("Contact B", lat = null, lon = null))
         advanceUntilIdle()
 
         assertFalse(vm.formState.value.canSubmit)
@@ -120,8 +235,7 @@ class TripPlanViewModelTest {
     @Test
     fun `reverseTrip swaps origin and destination`() = runTest {
         val vm = viewModel()
-        vm.setFrom(origin)
-        vm.setTo(destination)
+        setBothEndpoints(vm)
         advanceUntilIdle()
 
         vm.reverseTrip()
@@ -147,8 +261,7 @@ class TripPlanViewModelTest {
     @Test
     fun `a plan failure surfaces Error with the message`() = runTest {
         val vm = viewModel(plan = FakeTripPlanRepository(Result.failure(IOException("no route"))))
-        vm.setFrom(origin)
-        vm.setTo(destination)
+        setBothEndpoints(vm)
         advanceUntilIdle()
         assertEquals(PlanResult.Error("no route"), vm.planState.value)
     }


### PR DESCRIPTION
## Summary

Reworks the trip planner so location endpoints are typed and can't be edited as raw text when they shouldn't be.

- **Sealed `TripEndpoint`** replaces `PlaceItem`: `FreeText` / `Geocoded` / `AddressBook` / `CurrentLocation` / `MapPoint`. Only free text stays an editable autocomplete field; every resolved endpoint renders as a **non-editable, cancellable pill inside the field** (✕ clears it back to the empty field). Picking another input method (contacts / current location / map) overrides the current pill.
- **Android Geocoder fallback**: `DefaultGeocodeRepository` uses Pelias when a key is configured (`BuildFlavorUtils.isPeliasApiKeyDefined()`), else falls back to the on-device `android.location.Geocoder` so key-free builds still geocode. Degraded fallback (no typeahead / transit categories), region-bbox biased, off the main thread.
- **Stale-result fix**: changing or clearing an endpoint now drops a cached plan result (`replanOrClearResult`) so an old route can't remain on screen when the form is no longer submittable.
- **Semantic UI driving**: `testTagsAsResourceId` enabled app-wide and trip-plan fields tagged; fixed the contacts icon's mislabeled content description ("From:" → "Choose from contacts").

## Testing

- `TripPlanViewModelTest` updated for the new model, plus new coverage for endpoint clearing and stale-result invalidation. Passing.
- Built and exercised on a Pixel 7 Pro emulator: type → pick suggestion → in-field pill; clear a pill after planning → route sheet correctly disappears; Geocoder fallback returns results with no Pelias key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)