### PR TITLE
Dynamic stop sizes: dots at distant zoom + "more stops" banner

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/GoogleMapRenderer.kt
@@ -40,6 +40,8 @@ import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
+import org.onebusaway.android.map.render.StopBand
+import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.TripMarkerBitmaps
 import org.onebusaway.android.map.render.TripOverlay
@@ -47,6 +49,7 @@ import org.onebusaway.android.map.render.TripStopBitmaps
 import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.map.render.bikeZoomBand
+import org.onebusaway.android.map.render.stopIconKind
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.getRouteDisplayName
 import java.util.concurrent.TimeUnit
@@ -83,6 +86,8 @@ class GoogleMapRenderer(
     // and so survive [clearStatic]; [renderedFocusedStopId] is the focus the icons were last drawn for.
     private val stopMarkersByStopId = HashMap<String, Marker>()
     private var renderedFocusedStopId: String? = null
+    // The zoom band the stop icons were last drawn for (full icon vs dot); see [reconcileStopMarkers].
+    private var renderedStopBand = StopBand.FULL
 
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
@@ -198,7 +203,7 @@ class GoogleMapRenderer(
             )
         }
 
-        reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId)
+        reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
 
         if (snapshot.bikeshareVisible) {
             val band = bikeZoomBand(map.cameraPosition.zoom)
@@ -233,10 +238,11 @@ class GoogleMapRenderer(
     /**
      * Diff the stop markers against [stops] in place (the [reconcileVehicleMarkers] pattern): remove
      * markers whose id has left, add markers for new ids, and re-icon an existing marker only when its
-     * focused state flips. Unchanged stops keep their native marker, so they don't blink on a static
-     * redraw. Tracked in [stopMarkersByStopId] (not [staticMarkers]) so [clearStatic] leaves them be.
+     * icon kind changes — a focus flip or a zoom-band crossing ([band], full icon ⇄ dot). Unchanged
+     * stops keep their native marker, so they don't blink on a static redraw. Tracked in
+     * [stopMarkersByStopId] (not [staticMarkers]) so [clearStatic] leaves them be.
      */
-    private fun reconcileStopMarkers(stops: List<StopMarker>, focusedStopId: String?) {
+    private fun reconcileStopMarkers(stops: List<StopMarker>, focusedStopId: String?, band: StopBand) {
         val liveIds = stops.mapTo(HashSet()) { it.id }
         val gone = stopMarkersByStopId.iterator()
         while (gone.hasNext()) {
@@ -248,30 +254,43 @@ class GoogleMapRenderer(
             }
         }
         for (stop in stops) {
-            val isFocused = stop.id == focusedStopId
+            val kind = stopIconKind(stop.id == focusedStopId, band)
             val existing = stopMarkersByStopId[stop.id]
             if (existing == null) {
+                val (anchorX, anchorY) = stopAnchor(stop, kind)
                 val marker = map.addMarker(
                     MarkerOptions()
                         .position(stop.point.toLatLng())
-                        .icon(stopIcon(stop, isFocused))
+                        .icon(stopIcon(stop, kind))
                         .flat(true)
-                        .anchor(StopIconFactory.anchorX(stop.direction), StopIconFactory.anchorY(stop.direction))
+                        .anchor(anchorX, anchorY)
                 )!!
                 stopMarkersByStopId[stop.id] = marker
                 stopByMarker[marker] = stop
-            } else if ((stop.id == renderedFocusedStopId) != isFocused) {
-                // Re-icon only the marker that just lost focus and the one that just gained it (their
-                // focus state flipped).
-                existing.setIcon(stopIcon(stop, isFocused))
+            } else if (stopIconKind(stop.id == renderedFocusedStopId, renderedStopBand) != kind) {
+                // Only the markers whose icon kind changed need a new icon (and matching anchor: the
+                // full icon is anchored on its circle per direction, the dot at the marker center).
+                existing.setIcon(stopIcon(stop, kind))
+                val (anchorX, anchorY) = stopAnchor(stop, kind)
+                existing.setAnchor(anchorX, anchorY)
             }
         }
         renderedFocusedStopId = focusedStopId
+        renderedStopBand = band
     }
 
-    private fun stopIcon(stop: StopMarker, focused: Boolean): BitmapDescriptor =
-        if (focused) StopIconFactory.focusedStopIcon(stop.direction, stop.routeType)
-        else StopIconFactory.stopIcon(stop.direction, stop.routeType)
+    private fun stopIcon(stop: StopMarker, kind: StopIconKind): BitmapDescriptor = when (kind) {
+        StopIconKind.FULL -> StopIconFactory.stopIcon(stop.direction, stop.routeType)
+        StopIconKind.FULL_FOCUSED -> StopIconFactory.focusedStopIcon(stop.direction, stop.routeType)
+        StopIconKind.DOT -> StopIconFactory.dotStopIcon()
+        StopIconKind.DOT_FOCUSED -> StopIconFactory.focusedDotStopIcon()
+    }
+
+    private fun stopAnchor(stop: StopMarker, kind: StopIconKind): Pair<Float, Float> =
+        when (kind) {
+            StopIconKind.DOT, StopIconKind.DOT_FOCUSED -> 0.5f to 0.5f
+            else -> StopIconFactory.anchorX(stop.direction) to StopIconFactory.anchorY(stop.direction)
+        }
 
     /**
      * Tear down every native annotation and drop all marker-smoothing state. The adapter calls this from

--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/StopIconFactory.java
@@ -41,6 +41,7 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.map.render.StopBitmaps;
 import org.onebusaway.android.models.ObaRoute;
 
 import java.util.HashMap;
@@ -97,12 +98,22 @@ public final class StopIconFactory {
     private static final int NUM_DIRECTIONS = 9; // 8 directions + undirected mStops
 
     /**
-     * Icon cache keyed by route type, each containing a Bitmap array of size NUM_DIRECTIONS.
+     * Descriptor cache keyed by route type, each a BitmapDescriptor array of size NUM_DIRECTIONS. The
+     * descriptors (native texture wrappers) are built once so re-iconing markers — e.g. swapping every
+     * stop full icon ⇄ dot on a zoom-band crossing, up to the full stop cache at once (default 200, up
+     * to 2000) — reuses them instead of minting a fresh texture per marker (the cost that made the
+     * transition stutter).
      */
-    private static final SparseArray<Bitmap[]> sStopIcons = new SparseArray<>();
+    private static final SparseArray<BitmapDescriptor[]> sStopDescriptors = new SparseArray<>();
 
-    /** Focused (selected) variant of {@link #sStopIcons}. */
-    private static final SparseArray<Bitmap[]> sStopIconsFocused = new SparseArray<>();
+    /** Focused (selected) variant of {@link #sStopDescriptors}. */
+    private static final SparseArray<BitmapDescriptor[]> sStopDescriptorsFocused = new SparseArray<>();
+
+    /** The small directionless dot shown in place of the full icon at distant zoom (declutter). */
+    private static BitmapDescriptor sDotDescriptor;
+
+    /** The focused (accent) variant of {@link #sDotDescriptor}, so a selection stays visible far out. */
+    private static BitmapDescriptor sDotDescriptorFocused;
 
     /**
      * Route types that get distinct stop icons on the map.
@@ -172,6 +183,21 @@ public final class StopIconFactory {
         return getFocusedStopBitmapDescriptor(direction, routeType);
     }
 
+    /**
+     * The small dot shown in place of the full icon at distant zoom. Directionless and route-type
+     * agnostic (a neutral themed point), so the caller anchors it at the marker center (0.5, 0.5).
+     */
+    public static synchronized BitmapDescriptor dotStopIcon() {
+        ensureLoaded();
+        return sDotDescriptor;
+    }
+
+    /** The focused (accent) dot, shown for the selected stop at distant zoom. */
+    public static synchronized BitmapDescriptor focusedDotStopIcon() {
+        ensureLoaded();
+        return sDotDescriptorFocused;
+    }
+
     /** Marker anchor X for the given direction (positions the pin tip on the circle center). */
     public static float anchorX(String direction) {
         return getXPercentOffsetForDirection(direction);
@@ -225,9 +251,23 @@ public final class StopIconFactory {
                         (int) (bmp.getWidth() * FOCUS_ICON_SCALE),
                         (int) (bmp.getHeight() * FOCUS_ICON_SCALE), true);
             }
-            sStopIcons.put(routeType, icons);
-            sStopIconsFocused.put(routeType, iconsFocused);
+            sStopDescriptors.put(routeType, toDescriptors(icons));
+            sStopDescriptorsFocused.put(routeType, toDescriptors(iconsFocused));
         }
+
+        sDotDescriptor = BitmapDescriptorFactory.fromBitmap(
+                StopBitmaps.dot(mPx, r.getColor(R.color.theme_primary)));
+        sDotDescriptorFocused = BitmapDescriptorFactory.fromBitmap(
+                StopBitmaps.dot(mPx, r.getColor(R.color.map_stop_focus)));
+    }
+
+    /** Wraps each pre-rendered bitmap into a BitmapDescriptor once, so callers can reuse them. */
+    private static BitmapDescriptor[] toDescriptors(Bitmap[] bitmaps) {
+        BitmapDescriptor[] descriptors = new BitmapDescriptor[bitmaps.length];
+        for (int i = 0; i < bitmaps.length; i++) {
+            descriptors[i] = BitmapDescriptorFactory.fromBitmap(bitmaps[i]);
+        }
+        return descriptors;
     }
 
     /**
@@ -623,19 +663,19 @@ public final class StopIconFactory {
     }
 
     /**
-     * Looks up a stop icon from the given cache based on direction and route type.
+     * Looks up a cached stop descriptor by direction and route type.
      * Falls back to TYPE_BUS if the requested type is not found, then to the default marker.
      *
-     * @param cache     icon cache to look up from (normal or focused)
+     * @param cache     descriptor cache to look up from (normal or focused)
      * @param direction stop direction string
      * @param routeType one of ObaRoute.TYPE_* constants
      * @return BitmapDescriptor for the stop icon
      */
     @NonNull
-    private static BitmapDescriptor lookupStopIcon(SparseArray<Bitmap[]> cache, String direction,
-            int routeType) {
+    private static BitmapDescriptor lookupStopIcon(SparseArray<BitmapDescriptor[]> cache,
+            String direction, int routeType) {
         int normalizedType = normalizeRouteType(routeType);
-        Bitmap[] icons = cache.get(normalizedType);
+        BitmapDescriptor[] icons = cache.get(normalizedType);
         if (icons == null) {
             icons = cache.get(ObaRoute.TYPE_BUS);
         }
@@ -643,16 +683,16 @@ public final class StopIconFactory {
             Log.w(TAG, "Stop icons not initialized for type " + routeType);
             return BitmapDescriptorFactory.defaultMarker();
         }
-        return BitmapDescriptorFactory.fromBitmap(icons[getDirectionIndex(direction)]);
+        return icons[getDirectionIndex(direction)];
     }
 
     private static BitmapDescriptor getStopBitmapDescriptor(String direction, int routeType) {
-        return lookupStopIcon(sStopIcons, direction, routeType);
+        return lookupStopIcon(sStopDescriptors, direction, routeType);
     }
 
     @NonNull
     private static BitmapDescriptor getFocusedStopBitmapDescriptor(String direction,
             int routeType) {
-        return lookupStopIcon(sStopIconsFocused, direction, routeType);
+        return lookupStopIcon(sStopDescriptorsFocused, direction, routeType);
     }
 }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapHost.kt
@@ -128,6 +128,20 @@ class MapHost(
         _progress.value = inProgress
     }
 
+    private val _moreStopsAvailable = MutableStateFlow(false)
+
+    /**
+     * Whether the last viewport stop load was truncated (the API's `limitExceeded`): more stops match
+     * the viewport than were returned, so the UI can prompt the user to zoom in. Set by the stop
+     * loader on each load; cleared when leaving the nearby-stops view.
+     */
+    val moreStopsAvailable: StateFlow<Boolean> = _moreStopsAvailable.asStateFlow()
+
+    /** Set by the stop loader to the last response's `limitExceeded`; cleared on view changes. */
+    fun setMoreStopsAvailable(available: Boolean) {
+        _moreStopsAvailable.value = available
+    }
+
     private val _effects = MutableSharedFlow<MapEffect>(extraBufferCapacity = 8)
 
     /** One-shot events that need an Activity (e.g. the out-of-range prompt). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/MapViewModel.kt
@@ -146,6 +146,9 @@ class MapViewModel @Inject constructor(
     /** Whether a viewport/route load is in flight (the old `Callback.showProgress`). */
     val progress: StateFlow<Boolean> get() = mapHost.progress
 
+    /** Whether the last nearby-stops load was truncated (drives the "zoom in to see more stops" banner). */
+    val moreStopsAvailable: StateFlow<Boolean> get() = mapHost.moreStopsAvailable
+
     /** One-shot events that need an Activity (e.g. the out-of-range prompt). */
     val effects: SharedFlow<MapEffect> get() = mapHost.effects
 
@@ -259,6 +262,7 @@ class MapViewModel @Inject constructor(
         bikeController.stop()
         stopsController.clearStops(false)
         mapHost.setProgress(false)
+        mapHost.setMoreStopsAvailable(false)
     }
 
     // ----- Focus + taps (delegated to [stopsController], except the vehicle selection) -----

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/StopsMapController.kt
@@ -21,10 +21,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.onebusaway.android.api.ObaApi
 import org.onebusaway.android.api.ObaApiException
@@ -37,6 +39,7 @@ import org.onebusaway.android.map.render.CameraCommand
 import org.onebusaway.android.map.render.CameraSnapshot
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.primaryRouteType
+import org.onebusaway.android.map.render.stopZoomBand
 import org.onebusaway.android.region.RegionRepository
 import org.onebusaway.android.util.RegionUtils
 
@@ -78,6 +81,21 @@ class StopsMapController(
     private val routeTypeById = HashMap<String, Int>()
 
     private var loadJob: Job? = null
+
+    init {
+        // Derive the stop zoom band from the camera and publish it into the render snapshot, so a pure
+        // zoom (which changes no other snapshot field) re-fires the renderer to swap full icons ⇄ dots
+        // like any other snapshot change. Always-on (not tied to the viewport loader's start/stop), so
+        // it keeps updating in route mode where the loader is stopped. host.camera only emits on camera
+        // idle, and distinctUntilChanged collapses it to just the band crossings.
+        scope.launch {
+            host.camera
+                .filterNotNull()
+                .map { stopZoomBand(it.zoom.toFloat()) }
+                .distinctUntilChanged()
+                .collect { renderState.setStopBand(it) }
+        }
+    }
 
     /** (Re)start the viewport stop loader (the old StopMapController's camera watch). */
     fun start() {
@@ -129,12 +147,17 @@ class StopsMapController(
     }
 
     private fun onStopsLoaded(result: Result<NearbyStops?>) {
+        // Default the "more stops" banner off for this load; only a successful in-region result with
+        // limitExceeded turns it back on below. Clearing once up front means every early-out (error,
+        // null, out-of-range) leaves it cleared without having to remember to — the class of bug that
+        // previously left the banner stuck on after a truncated load was followed by a null one.
+        host.setMoreStopsAvailable(false)
         val nearby = result.getOrElse {
             MapUtils.showMapError((it as? ObaApiException)?.code ?: ObaApi.OBA_IO_EXCEPTION)
             return
         }
         if (nearby == null) {
-            // No endpoint yet (or a null no-op); do nothing (#615).
+            // No endpoint yet (or a null no-op); no stops loaded, so do nothing (#615).
             return
         }
         if (nearby.outOfRange) {
@@ -165,10 +188,13 @@ class StopsMapController(
             }
         }
 
+        // More stops match the viewport than the API returned: prompt the user to zoom in.
+        host.setMoreStopsAvailable(nearby.limitExceeded)
         showStops(nearby.stops, nearby.routes)
     }
 
     private fun notifyOutOfRange() {
+        host.setMoreStopsAvailable(false)
         host.emitEffect(MapEffect.OutOfRange)
     }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/MapRenderState.kt
@@ -133,6 +133,10 @@ data class MapRenderSnapshot(
     // The currently focused stop id, couriered so the vehicle info-window's "more info" tap can deep
     // link into TripDetails scoped to that stop (the legacy VehicleOverlay.Controller hook).
     val focusedStopId: String? = null,
+    // The zoom band the stops render in (full directional icon vs small dot). Derived from the camera
+    // by StopsMapController and carried here so a pure zoom re-fires the renderer like any other
+    // snapshot change — keeping the renderer a pure function of the snapshot (no live camera reads).
+    val stopBand: StopBand = StopBand.FULL,
 )
 
 /**
@@ -279,6 +283,11 @@ class MapRenderState {
 
     fun setFocusedStopId(stopId: String?) {
         _snapshot.update { it.copy(focusedStopId = stopId) }
+    }
+
+    /** Sets the stop zoom band (full icon vs dot); a no-op emission when unchanged (StateFlow dedups). */
+    fun setStopBand(band: StopBand) {
+        _snapshot.update { it.copy(stopBand = band) }
     }
 
     /** Selects (or deselects with null) a vehicle by trip id; the renderer shows its data marker. */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopBitmaps.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Shared builder for the small "dot" bus-stop marker shown at distant zoom (the full-icon ⇄ dot
+ * collapse). Lives in src/main so both map flavors share one definition — the Google flavor wraps the
+ * bitmap as a `BitmapDescriptor`, maplibre as an `Icon` — mirroring [BikeBitmaps]. Directionless and
+ * route-type agnostic; the dot's [color][dot] distinguishes a normal vs focused stop.
+ */
+object StopBitmaps {
+    /**
+     * A filled circle in [fillColor] with a thin white outline for contrast against the map, sized
+     * from [baseIconPx] (the full stop icon size) so a dense viewport reads as points.
+     */
+    @JvmStatic
+    fun dot(baseIconPx: Int, fillColor: Int): Bitmap {
+        val sizePx = max(6, (baseIconPx * 0.5f).roundToInt())
+        val bm = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bm)
+        val center = sizePx / 2f
+        val stroke = max(1f, sizePx / 10f)
+        val radius = center - stroke
+
+        val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.FILL
+            color = fillColor
+        }
+        canvas.drawCircle(center, center, radius, fill)
+
+        val outline = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = stroke
+            color = Color.WHITE
+        }
+        canvas.drawCircle(center, center, radius, outline)
+        return bm
+    }
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/render/StopZoomBand.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+/**
+ * The zoom at or above which stops show their full directional icon; below it they collapse to a
+ * small dot to reduce clutter when a lot of stops are on screen. Tunable — mirrors the spirit of the
+ * bike zoom bands ([bikeZoomBand]).
+ */
+const val STOP_DOT_ZOOM_THRESHOLD = 15f
+
+/** Whether a stop renders as a small dot (distant zoom) or its full directional icon (close zoom). */
+enum class StopBand { DOT, FULL }
+
+/** The [StopBand] a stop falls in at [zoom]: a dot below [STOP_DOT_ZOOM_THRESHOLD], else the full icon. */
+fun stopZoomBand(zoom: Float): StopBand =
+    if (zoom < STOP_DOT_ZOOM_THRESHOLD) StopBand.DOT else StopBand.FULL
+
+/** The icon variants a stop marker can show: full icon (normal/focused) or dot (normal/focused). */
+enum class StopIconKind { FULL, FULL_FOCUSED, DOT, DOT_FOCUSED }
+
+/**
+ * The icon a stop marker should show given whether it's the [focused] stop and the current zoom
+ * [band]. The focused stop always gets a distinct (accent) icon — the enlarged full icon up close,
+ * an accent-colored dot far out — so a selection stays visible at every zoom. Pure, so the renderers'
+ * "did this marker's icon change?" decision is unit-testable and identical across both map flavors.
+ */
+fun stopIconKind(focused: Boolean, band: StopBand): StopIconKind = when {
+    band == StopBand.DOT -> if (focused) StopIconKind.DOT_FOCUSED else StopIconKind.DOT
+    focused -> StopIconKind.FULL_FOCUSED
+    else -> StopIconKind.FULL
+}

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -21,11 +21,18 @@ import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -37,9 +44,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -270,6 +280,23 @@ fun MapFeature(
         initialZoom = seed.zoom,
     )
 
+    // "Zoom in to see more stops" — shown when the viewport stop load was truncated (the API's
+    // limitExceeded), i.e. more stops match the viewport than were returned. Driven purely by map state.
+    val moreStops by mapViewModel.moreStopsAvailable.collectAsStateWithLifecycle()
+    // The map sits below HomeTopBar (which already consumes the status-bar inset), so the banner is
+    // flush at the map's top edge — no extra inset. clipToBounds clips the upward slide at that edge so
+    // the bar tucks up behind the title bar instead of drawing over it.
+    Box(
+        Modifier
+            .fillMaxSize()
+            .clipToBounds()
+    ) {
+        MoreStopsBanner(
+            visible = moreStops,
+            modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
+        )
+    }
+
     // The welcome tutorial's map-stop spotlight, wired from the flavor-neutral map seam (the published
     // projector + the shared stop list) so this host knows nothing of the underlying map SDK. A tap
     // focuses the chosen stop exactly like a marker tap, continuing into the arrivals tutorial.
@@ -329,6 +356,45 @@ fun MapFeature(
             )
         },
     )
+}
+
+/**
+ * The "zoom in to see more stops" hint: a full-width, text-height bar at the top edge of the map that
+ * slides down to appear and up (tucking behind the home top bar) to disappear. Shown while the last
+ * viewport stop load was truncated by the API; purely state-driven, no dismiss button. The status-bar
+ * inset is already consumed by HomeTopBar above the map, so the caller's slot adds no inset — only the
+ * slide clipping (clipToBounds).
+ */
+@Composable
+private fun MoreStopsBanner(visible: Boolean, modifier: Modifier = Modifier) {
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier,
+        enter = slideInVertically(initialOffsetY = { -it }),
+        exit = slideOutVertically(targetOffsetY = { -it }),
+    ) {
+        // A plain Box (not a Surface): a non-clickable Surface still consumes pointer events across its
+        // bounds, so a pan/tap/pinch that starts on the banner strip would be swallowed instead of
+        // reaching the map underneath. A Box with just background/shadow is not hit-testable, so gestures
+        // fall through to the map.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .shadow(4.dp)
+                // A neutral, informational tint (not a warning), alpha'd so the map shows through slightly.
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)),
+        ) {
+            Text(
+                text = stringResource(R.string.map_zoom_in_for_more_stops),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
 }
 
 /** The viewport (or device) is outside the current region (ported from GoogleMapHost.showOutOfRange). */

--- a/onebusaway-android/src/main/res/drawable/selected_map_stop_icon.xml
+++ b/onebusaway-android/src/main/res/drawable/selected_map_stop_icon.xml
@@ -90,7 +90,7 @@
             <stroke
                 android:width="7dp"
                 android:color="@android:color/transparent" />
-            <solid android:color="#FF9500" />
+            <solid android:color="@color/map_stop_focus" />
             <size
                 android:width="@dimen/map_stop_icon_size_fill"
                 android:height="@dimen/map_stop_icon_size_fill" />

--- a/onebusaway-android/src/main/res/values/colors.xml
+++ b/onebusaway-android/src/main/res/values/colors.xml
@@ -26,6 +26,9 @@
     <color name="theme_primary_variant">@color/brand_color_dark</color>
     <color name="theme_accent">#5db53b</color>
 
+    <!-- The focused/selected map stop highlight: the selected_map_stop_icon.xml fill + the focused dot. -->
+    <color name="map_stop_focus">#FF9500</color>
+
     <color name="body_text_1">#de000000</color>
     <color name="body_text_2">#8a000000</color>
     <color name="body_text_disabled">#44000000</color>

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -647,6 +647,7 @@
     <string name="preferences_experimental_regions_title">Experimental regions</string>
     <string name="preferences_experimental_regions_summary">Enables regions that may be unstable
     </string>
+    <string name="map_zoom_in_for_more_stops">Zoom in to see more stops</string>
     <string name="preferences_map_stop_cache_size_title">Map stop cache size</string>
     <string name="preferences_map_stop_cache_size_summary">Max bus stops kept on the map while panning (currently %1$d)</string>
     <string name="preferences_map_stop_cache_size_error">Enter a number between %1$d and %2$d</string>

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreRenderer.kt
@@ -38,6 +38,8 @@ import org.onebusaway.android.map.render.CorrectionSmoother
 import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.map.render.MapRenderState
 import org.onebusaway.android.map.render.MapVehicles
+import org.onebusaway.android.map.render.StopBand
+import org.onebusaway.android.map.render.StopIconKind
 import org.onebusaway.android.map.render.StopMarker
 import org.onebusaway.android.map.render.TripMarkerBitmaps
 import org.onebusaway.android.map.render.TripOverlay
@@ -45,6 +47,7 @@ import org.onebusaway.android.map.render.TripStopBitmaps
 import org.onebusaway.android.map.render.VehicleBitmaps
 import org.onebusaway.android.map.render.VehicleMarker
 import org.onebusaway.android.map.render.bikeZoomBand
+import org.onebusaway.android.map.render.stopIconKind
 import org.onebusaway.android.util.MyTextUtils
 import org.onebusaway.android.util.getRouteDisplayName
 
@@ -81,6 +84,8 @@ class MapLibreRenderer(
     // icons were last drawn for. They live until MapView.onDestroy(), like vehicleMarkersByTripId.
     private val stopMarkersByStopId = HashMap<String, Marker>()
     private var renderedFocusedStopId: String? = null
+    // The zoom band the stop icons were last drawn for (full icon vs dot); see [reconcileStopMarkers].
+    private var renderedStopBand = StopBand.FULL
 
     private val bikeByMarker = HashMap<Marker, BikeMarker>()
 
@@ -152,7 +157,7 @@ class MapLibreRenderer(
             )
         }
 
-        reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId)
+        reconcileStopMarkers(snapshot.stops, snapshot.focusedStopId, snapshot.stopBand)
 
         if (snapshot.bikeshareVisible) {
             val band = bikeZoomBand(map.cameraPosition.zoom.toFloat())
@@ -192,10 +197,11 @@ class MapLibreRenderer(
     /**
      * Diff the stop markers against [stops] in place (the [reconcileVehicleMarkers] pattern): remove
      * markers whose id has left, add markers for new ids, and re-icon an existing marker only when its
-     * focused state flips. Unchanged stops keep their native marker, so they don't blink on a static
-     * redraw. Tracked in [stopMarkersByStopId] (not [staticAnnotations]) so a static redraw leaves them.
+     * icon kind changes — a focus flip or a zoom-band crossing ([band], full icon ⇄ dot). Unchanged
+     * stops keep their native marker, so they don't blink on a static redraw. Tracked in
+     * [stopMarkersByStopId] (not [staticAnnotations]) so a static redraw leaves them.
      */
-    private fun reconcileStopMarkers(stops: List<StopMarker>, focusedStopId: String?) {
+    private fun reconcileStopMarkers(stops: List<StopMarker>, focusedStopId: String?, band: StopBand) {
         val liveIds = stops.mapTo(HashSet()) { it.id }
         val gone = stopMarkersByStopId.iterator()
         while (gone.hasNext()) {
@@ -207,26 +213,30 @@ class MapLibreRenderer(
             }
         }
         for (stop in stops) {
-            val isFocused = stop.id == focusedStopId
+            val kind = stopIconKind(stop.id == focusedStopId, band)
             val existing = stopMarkersByStopId[stop.id]
             if (existing == null) {
                 val marker = map.addMarker(
-                    MarkerOptions().position(stop.point.toLatLng()).icon(stopIcon(stop, isFocused))
+                    MarkerOptions().position(stop.point.toLatLng()).icon(stopIcon(stop, kind))
                 )
                 stopMarkersByStopId[stop.id] = marker
                 stopByMarker[marker] = stop
-            } else if ((stop.id == renderedFocusedStopId) != isFocused) {
-                // Re-icon only the marker that just lost focus and the one that just gained it (their
-                // focus state flipped).
-                existing.icon = stopIcon(stop, isFocused)
+            } else if (stopIconKind(stop.id == renderedFocusedStopId, renderedStopBand) != kind) {
+                // Only the markers whose icon kind changed need a new icon (maplibre centers the icon
+                // on the position, so the dot lands on the stop with no anchor change).
+                existing.icon = stopIcon(stop, kind)
             }
         }
         renderedFocusedStopId = focusedStopId
+        renderedStopBand = band
     }
 
-    private fun stopIcon(stop: StopMarker, focused: Boolean): Icon =
-        if (focused) MapLibreStopIcons.focusedIconForDirection(context, stop.direction)
-        else MapLibreStopIcons.iconForDirection(context, stop.direction)
+    private fun stopIcon(stop: StopMarker, kind: StopIconKind): Icon = when (kind) {
+        StopIconKind.FULL -> MapLibreStopIcons.iconForDirection(stop.direction)
+        StopIconKind.FULL_FOCUSED -> MapLibreStopIcons.focusedIconForDirection(stop.direction)
+        StopIconKind.DOT -> MapLibreStopIcons.dotIcon()
+        StopIconKind.DOT_FOCUSED -> MapLibreStopIcons.focusedDotIcon()
+    }
 
     /**
      * Update the dynamic layer for one display frame: the route's live [vehicles] (null off route mode)

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/MapLibreStopIcons.java
@@ -34,6 +34,7 @@ import org.maplibre.android.annotations.IconFactory;
 
 import org.onebusaway.android.R;
 import org.onebusaway.android.app.Application;
+import org.onebusaway.android.map.render.StopBitmaps;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -79,8 +80,18 @@ public final class MapLibreStopIcons {
 
     private static final int NUM_DIRECTIONS = 9;
 
-    private static final Bitmap[] bus_stop_icons = new Bitmap[NUM_DIRECTIONS];
-    private static final Bitmap[] bus_stop_icons_focused = new Bitmap[NUM_DIRECTIONS];
+    // The Icons (native texture wrappers) are built once so re-iconing markers — e.g. swapping every
+    // stop full icon ⇄ dot on a zoom-band crossing, up to the full stop cache at once (default 200, up
+    // to 2000) — reuses them instead of wrapping a fresh Icon per marker (the cost that made the
+    // transition stutter).
+    private static final Icon[] bus_stop_icons = new Icon[NUM_DIRECTIONS];
+    private static final Icon[] bus_stop_icons_focused = new Icon[NUM_DIRECTIONS];
+
+    /** The small directionless dot shown in place of the full icon at distant zoom (declutter). */
+    private static Icon dot_stop_icon;
+
+    /** The focused (accent) variant of {@link #dot_stop_icon}, so a selection stays visible far out. */
+    private static Icon dot_stop_icon_focused;
 
     private static final float FOCUS_ICON_SCALE = 1.5f;
 
@@ -100,15 +111,31 @@ public final class MapLibreStopIcons {
     }
 
     /** The normal (unfocused) stop icon for a direction string ("N".."NW" / "null"). */
-    public static synchronized Icon iconForDirection(Context context, String direction) {
+    public static synchronized Icon iconForDirection(String direction) {
         ensureLoaded();
-        return IconFactory.getInstance(context).fromBitmap(bus_stop_icons[indexFor(direction)]);
+        return bus_stop_icons[indexFor(direction)];
     }
 
     /** The focused (1.5x) stop icon for a direction string. */
-    public static synchronized Icon focusedIconForDirection(Context context, String direction) {
+    public static synchronized Icon focusedIconForDirection(String direction) {
         ensureLoaded();
-        return IconFactory.getInstance(context).fromBitmap(bus_stop_icons_focused[indexFor(direction)]);
+        return bus_stop_icons_focused[indexFor(direction)];
+    }
+
+    /**
+     * The small dot shown in place of the full icon at distant zoom — directionless and route-type
+     * agnostic (a neutral themed point). maplibre centers the icon on the position, so it lands on
+     * the stop without anchor math.
+     */
+    public static synchronized Icon dotIcon() {
+        ensureLoaded();
+        return dot_stop_icon;
+    }
+
+    /** The focused (accent) dot, shown for the selected stop at distant zoom. */
+    public static synchronized Icon focusedDotIcon() {
+        ensureLoaded();
+        return dot_stop_icon_focused;
     }
 
     private static int indexFor(String direction) {
@@ -132,17 +159,19 @@ public final class MapLibreStopIcons {
         mArrowPaintStroke.setStrokeWidth(1.0f);
         mArrowPaintStroke.setAntiAlias(true);
 
+        IconFactory iconFactory = IconFactory.getInstance(Application.get());
         String[] directions = {NORTH, NORTH_WEST, WEST, SOUTH_WEST, SOUTH, SOUTH_EAST, EAST, NORTH_EAST, NO_DIRECTION};
         for (int i = 0; i < directions.length; i++) {
-            bus_stop_icons[i] = createBusStopIcon(directions[i], false);
-            bus_stop_icons_focused[i] = createBusStopIcon(directions[i], true);
+            bus_stop_icons[i] = iconFactory.fromBitmap(createBusStopIcon(directions[i], false));
+            Bitmap focused = createBusStopIcon(directions[i], true);
+            focused = Bitmap.createScaledBitmap(focused,
+                    (int) (focused.getWidth() * FOCUS_ICON_SCALE),
+                    (int) (focused.getHeight() * FOCUS_ICON_SCALE), true);
+            bus_stop_icons_focused[i] = iconFactory.fromBitmap(focused);
         }
-        for (int i = 0; i < NUM_DIRECTIONS; i++) {
-            Bitmap bmp = bus_stop_icons_focused[i];
-            bus_stop_icons_focused[i] = Bitmap.createScaledBitmap(bmp,
-                    (int) (bmp.getWidth() * FOCUS_ICON_SCALE),
-                    (int) (bmp.getHeight() * FOCUS_ICON_SCALE), true);
-        }
+
+        dot_stop_icon = iconFactory.fromBitmap(StopBitmaps.dot(mPx, r.getColor(R.color.theme_primary)));
+        dot_stop_icon_focused = iconFactory.fromBitmap(StopBitmaps.dot(mPx, r.getColor(R.color.map_stop_focus)));
     }
 
     @SuppressWarnings("deprecation")

--- a/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
+++ b/onebusaway-android/src/test/java/org/onebusaway/android/map/render/StopZoomBandTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.android.map.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-logic tests for the stop dot/full zoom banding the renderers use to decide a stop marker's
+ * icon — the band threshold and the focus/band → icon-kind mapping, shared identically by both map
+ * flavors. The actual bitmap build + marker reconcile is exercised on device.
+ */
+class StopZoomBandTest {
+
+    @Test
+    fun `below the threshold is the dot band, at or above is the full band`() {
+        assertEquals(StopBand.DOT, stopZoomBand(STOP_DOT_ZOOM_THRESHOLD - 0.01f))
+        assertEquals(StopBand.DOT, stopZoomBand(0f))
+        assertEquals(StopBand.FULL, stopZoomBand(STOP_DOT_ZOOM_THRESHOLD))
+        assertEquals(StopBand.FULL, stopZoomBand(STOP_DOT_ZOOM_THRESHOLD + 0.01f))
+        assertEquals(StopBand.FULL, stopZoomBand(21f))
+    }
+
+    @Test
+    fun `the band flips at zoom 15 (pins the threshold constant, not just the boundary)`() {
+        // Literal anchors (not STOP_DOT_ZOOM_THRESHOLD) so retuning the constant is a deliberate change
+        // that has to update this test — the ± boundary cases above would otherwise silently follow it.
+        assertEquals(15f, STOP_DOT_ZOOM_THRESHOLD, 0f)
+        assertEquals(StopBand.DOT, stopZoomBand(14.99f))
+        assertEquals(StopBand.FULL, stopZoomBand(15f))
+    }
+
+    @Test
+    fun `at the dot band the focused stop gets the accent dot, others the plain dot`() {
+        assertEquals(StopIconKind.DOT, stopIconKind(focused = false, band = StopBand.DOT))
+        assertEquals(StopIconKind.DOT_FOCUSED, stopIconKind(focused = true, band = StopBand.DOT))
+    }
+
+    @Test
+    fun `at the full band focus selects the enlarged icon`() {
+        assertEquals(StopIconKind.FULL, stopIconKind(focused = false, band = StopBand.FULL))
+        assertEquals(StopIconKind.FULL_FOCUSED, stopIconKind(focused = true, band = StopBand.FULL))
+    }
+}


### PR DESCRIPTION
Stacked on `map-icon-cache`.

## What

At distant (zoomed-out) zoom the map gets crowded, so this transitions the full directional bus-stop icons to small **dots**, and adds a banner when the API truncates the stop list.

### Dot zoom collapse
- A pure classifier in `map/render` (`stopZoomBand` / `stopIconKind`) decides each stop's icon: `FULL`, `FULL_FOCUSED`, `DOT`, or `DOT_FOCUSED` (an accent dot so a selection stays visible far out). JVM-unit-tested (`StopZoomBandTest`).
- The dot bitmap is a shared `StopBitmaps.dot()` in `src/main`; the focused dot uses a new `map_stop_focus` color that `selected_map_stop_icon.xml` now also references (one source of truth for the orange highlight).
- Both flavor renderers reconcile stop markers **in place**, re-iconing only the markers whose icon kind changed (a focus flip or a zoom-band crossing) — no blink.

### Band is a snapshot field (declarative)
- The zoom band is a first-class `MapRenderSnapshot` field, derived from the camera by `StopsMapController` (an always-on `host.camera` collector + `distinctUntilChanged`) and written via `setStopBand`. A pure zoom re-fires the renderer like any other snapshot change, so the renderers stay pure functions of the snapshot (no live camera reads for stops). The collector is independent of the viewport loader, so it keeps updating in route mode.

### Perf
- `StopIconFactory` / `MapLibreStopIcons` now build their `BitmapDescriptor` / `Icon` caches **once** instead of re-wrapping per call. Re-iconing ~1000 markers on a band crossing reuses cached descriptors — fixes a 200–700ms transition stutter on dense viewports (Pixel 7, 1000-stop cache).

### "Zoom in to see more stops" banner
- A translucent, theme `errorContainer`-colored pill that slides down/up at the very top of the map, shown when the stops API reports `limitExceeded` (more stops match the viewport than were returned). Driven by a new `MapHost.moreStopsAvailable` flag mirroring the existing `progress` flow; cleared on view changes. Home map only.

## Testing
- Both Google and MapLibre flavors compile; `StopZoomBandTest` passes.
- Installed + exercised on a Pixel 7: dot transition (no blink), accent focused dot, smooth band crossing after descriptor caching, banner slide/tuck behind the title bar.

## Follow-up (not in this PR)
- The bike layer still reads `map.cameraPosition.zoom` live in `renderStatic` for its own zoom bands. Migrating it to the same snapshot-band approach would make both layers consistent (and fix a latent pure-zoom staleness in bikes). Left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)