### PR TITLE
Lint: typographic quotes in base strings (un-baseline 39 TypographyQuotes)

### DIFF
--- a/onebusaway-android/lint-baseline.xml
+++ b/onebusaway-android/lint-baseline.xml
@@ -2619,28 +2619,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        &lt;item>What\&apos;s New?&lt;/item>"
-        errorLine2="                   ~">
-        <location
-            file="src/main/res/values/arrays.xml"
-            line="21"
-            column="20"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        &lt;item>What\&apos;s New?&lt;/item>"
-        errorLine2="                   ~">
-        <location
-            file="src/main/res/values/arrays.xml"
-            line="29"
-            column="20"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="        &lt;item>L\&apos;autobus non è passato&lt;/item>"
         errorLine2="                ~">
         <location
@@ -2658,17 +2636,6 @@
             file="src/main/res/values-it/arrays.xml"
             line="80"
             column="17"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        &lt;item>The bus doesn\&apos;t stop here&lt;/item>"
-        errorLine2="                            ~">
-        <location
-            file="src/main/res/values/arrays.xml"
-            line="81"
-            column="29"/>
     </issue>
 
     <issue
@@ -2773,17 +2740,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;generic_comm_error&quot;>Sorry, there was a communication error and we can\&apos;t show this"
-        errorLine2="                                                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="42"
-            column="89"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Spiacenti, impossibile trovare questa fermata. Se si tratta di una scorciatoia, è possibile che il link sia obsoleto o che l\&apos;area selezionata sia errata. (La tua area è: %1$s. Cambia in \&amp;quot;Preferenze-&amp;gt;La tua area\&amp;quot;)&lt;/string>"
         errorLine2="                                                                                                                                                                                      ~">
         <location
@@ -2800,17 +2756,6 @@
         <location
             file="src/main/res/values-fi/strings.xml"
             line="44"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;route_not_found_error_no_region&quot;>Sorry, that particular route can\&apos;t be found. If"
-        errorLine2="                                                   ^">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="45"
             column="52"/>
     </issue>
 
@@ -2838,17 +2783,6 @@
 
     <issue
         id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;route_not_found_error_with_region_name&quot;>Sorry, that particular route can\&apos;t be"
-        errorLine2="                                                          ^">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="51"
-            column="59"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;route_not_found_error_with_region_name&quot;>Lo sentimos, esa ruta especificada no puede ser"
         errorLine2="                                                          ^">
@@ -2866,17 +2800,6 @@
         <location
             file="src/main/res/values-fi/strings.xml"
             line="56"
-            column="51"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;stop_not_found_error_no_region&quot;>Sorry, that particular stop can\&apos;t be found. If"
-        errorLine2="                                                  ^">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="57"
             column="51"/>
     </issue>
 
@@ -2904,17 +2827,6 @@
 
     <issue
         id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Sorry, that particular stop can\&apos;t be"
-        errorLine2="                                                         ^">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="63"
-            column="58"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;stop_not_found_error_with_region_name&quot;>Lo sentimos, esa parada especificada no puede ser"
         errorLine2="                                                         ^">
@@ -2926,17 +2838,6 @@
 
     <issue
         id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;out_of_memory_error&quot;>Sorry, there isn\&apos;t enough available memory to handle that"
-        errorLine2="                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="70"
-            column="57"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Verde significa \&amp;quot;In orario\&amp;quot;&lt;/string>"
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
@@ -2944,17 +2845,6 @@
             file="src/main/res/values-it/strings.xml"
             line="73"
             column="44"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;bad_gateway_error&quot;>%1$s\&apos;s servers are overloaded. Please excuse us!&lt;/string>"
-        errorLine2="                                          ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="74"
-            column="43"/>
     </issue>
 
     <issue
@@ -3036,17 +2926,6 @@
 
     <issue
         id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_whatsnew_title&quot;>What\&apos;s New?&lt;/string>"
-        errorLine2="                                                 ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="102"
-            column="50"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Vihreä tarkoittaa \&quot;ajoissa\&quot;&lt;/string>"
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
@@ -3092,17 +2971,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Green means \&quot;On time\&quot;&lt;/string>"
-        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="106"
-            column="44"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;main_help_legend_ontime&quot;>Verde significa \&quot;A tiempo\&quot;&lt;/string>"
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -3114,45 +2982,12 @@
     <issue
         id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Blue means \&quot;Running late\&quot;&lt;/string>"
-        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="107"
-            column="42"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;main_help_legend_late&quot;>Azul significa \&quot;Llegando tarde\&quot;&lt;/string>"
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-es/strings.xml"
             line="108"
             column="42"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_early&quot;>Red means \&quot;Running early\&quot;&lt;/string>"
-        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="108"
-            column="43"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;main_help_legend_scheduled&quot;>Gray means \&quot;Scheduled arrival\&quot; - We don\&apos;t know"
-        errorLine2="                                                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="109"
-            column="89"/>
     </issue>
 
     <issue
@@ -3197,17 +3032,6 @@
             file="src/main/res/values-fi/strings.xml"
             line="120"
             column="44"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;main_outofrange&quot;>You\&apos;re looking at a place outside the %1$s service area.\n\nMove"
-        errorLine2="                                       ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="124"
-            column="40"/>
     </issue>
 
     <issue
@@ -3322,17 +3146,6 @@
 
     <issue
         id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Your feedback will be sent to %1$s. If you check \&quot;Include system logs\&quot;, real-time location information from your device recorded as you approached your destination stop will be shared with %1$s so developers can improve the destination reminder feature.\n\nChange your preference for sharing system logs in Settings.&lt;/string>"
-        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="314"
-            column="39"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;alert_hidden_snackbar_text&quot;>L\&apos;avviso è nascosto&lt;/string>"
         errorLine2="                                                ~">
@@ -3367,28 +3180,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;main_changelocationmode&quot;>Your current device &quot;Location method&quot; setting may fail to"
-        errorLine2="                                           ^">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="324"
-            column="44"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;route_info_no_shape_data&quot;>Sorry, map information isn\&apos;t available for this route"
-        errorLine2="                                                                       ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="337"
-            column="72"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Marcar como favorito a \&quot;%s\&quot; para:&lt;/string>"
         errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -3405,28 +3196,6 @@
         <location
             file="src/main/res/values-es/strings.xml"
             line="353"
-            column="56"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_star&quot;>Star Route \&quot;%s\&quot; for:&lt;/string>"
-        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="363"
-            column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
-        errorLine1="    &lt;string name=&quot;route_favorite_options_title_unstar&quot;>Remove star from \&quot;%s\&quot; for:&lt;/string>"
-        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="364"
             column="56"/>
     </issue>
 
@@ -3494,17 +3263,6 @@
             file="src/main/res/values-it/strings.xml"
             line="443"
             column="261"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;trip_list_notrips&quot;>You don\&apos;t have any reminders.\n\nYou can create reminders by"
-        errorLine2="                                             ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="447"
-            column="46"/>
     </issue>
 
     <issue
@@ -3587,17 +3345,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;region_load_failed_title&quot;>Couldn\&apos;t load regions&lt;/string>"
-        errorLine2="                                                   ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="520"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;region_dialog_message&quot;>Ti trovi nell\&apos;area di %1$s?&lt;/string>"
         errorLine2="                                                       ~">
         <location
@@ -3626,17 +3373,6 @@
             file="src/main/res/values-fi/strings.xml"
             line="560"
             column="53"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;no_play_store&quot;>Your device doesn\&apos;t have the Play Store installed. Please find"
-        errorLine2="                                                   ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="561"
-            column="52"/>
     </issue>
 
     <issue
@@ -3703,17 +3439,6 @@
             file="src/main/res/values-it/strings.xml"
             line="584"
             column="56"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        show arrival info in the header at the top of the screen (doesn\&apos;t affect map view)"
-        errorLine2="                                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="608"
-            column="73"/>
     </issue>
 
     <issue
@@ -3796,17 +3521,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;preferences_restore_summary&quot;>Restores from a previous backup. After selecting this option, you\&apos;ll be asked to pick a file. Please select the backup file (e.g., &quot;db.backup&quot; or &quot;%1$s.backup&quot;), which may be in your &quot;Documents&quot; folder or any location where you saved the backup.&lt;/string>"
-        errorLine2="                                                                                                                 ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="642"
-            column="114"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;tutorial_opt_out_dialog_text&quot;>Desideri che vengano mostrati popup informativi per l\&apos;utilizzo di %1$s? Puoi sempre attivare e disattivare i popup nelle impostazioni, o mostrare il tutorial in seguito premendo su Aiuto.&lt;/string>"
         errorLine2="                                                                                                      ~">
         <location
@@ -3873,17 +3587,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        won\&apos;t be available! Go ahead?"
-        errorLine2="            ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="664"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;about_contributors_intro&quot;>I nostri dedicati contributori migliorano la funzionalità e l\&apos;esperienza utente dell\&apos;applicazione:&lt;/string>"
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -3906,28 +3609,6 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;ri_open_camera_problem&quot;>Camera couldn\&apos;t be opened.&lt;/string>"
-        errorLine2="                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="719"
-            column="57"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;ri_resize_image_problem&quot;>Image couldn\&apos;t be resized - using full size.&lt;/string>"
-        errorLine2="                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="720"
-            column="57"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;tripplanner_no_contact&quot;>Non c\&apos;è un contatto per la pianificazione del viaggio in ques\&apos;area.&lt;/string>"
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -3945,17 +3626,6 @@
             file="src/main/res/values-pl/strings.xml"
             line="760"
             column="54"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        couldn\&apos;t see you in the dark? Hold up your flashing Night Light and make yourself visible!"
-        errorLine2="               ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="798"
-            column="16"/>
     </issue>
 
     <issue
@@ -4004,17 +3674,6 @@
 
     <issue
         id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="        if the bus is early (red) or late (blue). On time = green background. If we don\&apos;t know"
-        errorLine2="                                                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="817"
-            column="89"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
         message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Dotknięcie tej opcji spowoduje wyczyszczenie znaczników czasu \&apos;Przypomnij mi później\&apos; i \&apos;Nie przeszkadzaj mi\&apos; związanych z prośbami o darowizny.&lt;/string>"
         errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
@@ -4027,56 +3686,12 @@
     <issue
         id="TypographyQuotes"
         message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;tutorial_recent_stops_routes_text&quot;>Find the stops and routes that you\&apos;ve recently"
-        errorLine2="                                                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="831"
-            column="89"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;tutorial_welcome_map_stop_title&quot;>Here\&apos;s a stop&lt;/string>"
-        errorLine2="                                                        ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="838"
-            column="57"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;about_contributors_intro&quot;>Our dedicated contributors improve the app\&apos;s functionality and user experience:&lt;/string>"
-        errorLine2="                                                                                       ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="857"
-            column="88"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
         errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_body&quot;>%1$s è un\&apos;organizzazione gestita da volontari con quasi nessun finanziamento. Abbiamo bisogno del tuo aiuto per mantenere questa app in funzione.&lt;/string>"
         errorLine2="                                                          ~">
         <location
             file="src/main/res/values-it/strings.xml"
             line="922"
             column="59"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;tripplanner_error_path_not_found&quot;>Couldn\&apos;t find a matching route between origin and destination&lt;/string>"
-        errorLine2="                                                           ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="924"
-            column="60"/>
     </issue>
 
     <issue
@@ -4147,50 +3762,6 @@
 
     <issue
         id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_title&quot;>Please don\&apos;t dismiss this request&lt;/string>"
-        errorLine2="                                                            ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1126"
-            column="61"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;donation_dismiss_dialog_dont_want_to_help_button&quot;>I Don\&apos;t Want to Help&lt;/string>"
-        errorLine2="                                                                          ~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1129"
-            column="75"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace apostrophe (&apos;) with typographic apostrophe (’, &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;donation_learn_more_explanation&quot; tools:ignore=&quot;TypographyOther&quot;>We have big plans to improve %1$s, but we can\&apos;t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let\&apos;s shape the future of transit together!\n\nThank you,\nThe %1$s Team&lt;/string>"
-        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1135"
-            column="83"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
-        message="Replace straight quotes (&apos;&apos;) with directional quotes (‘’, &amp;#8216; and &amp;#8217;) ?"
-        errorLine1="    &lt;string name=&quot;preferences_reset_donation_timestamps_summary&quot;>Tapping this option will clear both the \&apos;Remind Me Later\&apos; and \&apos;Don\&apos;t Bother Me\&apos; timestamps associated with donation requests.&lt;/string>"
-        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1137"
-            column="66"/>
-    </issue>
-
-    <issue
-        id="TypographyQuotes"
         message="Replace straight quotes (&quot;) with directional quotes (“”, &amp;#8220; and &amp;#8221;) ?"
         errorLine1="    &lt;string name=&quot;feedback_log_guide&quot;>Tus comentarios serán enviados a %1$s. Si marcas \&quot;Incluir registros del sistema\&quot;, la información de ubicación en tiempo real de tu dispositivo registrada al acercarte a tu parada de destino será compartida con %1$s para que los desarrolladores puedan mejorar la función de recordatorio de destino.\n\nCambia tu preferencia para compartir registros del sistema en Configuración.&lt;/string>"
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
@@ -4206,6 +3777,7 @@
         <location
             file="src/main/res/drawable-nodpi/wmata.jpg"/>
     </issue>
+
 
 
 </issues>

--- a/onebusaway-android/src/main/res/values/arrays.xml
+++ b/onebusaway-android/src/main/res/values/arrays.xml
@@ -18,7 +18,7 @@
     <string-array name="main_help_options">
         <item>Show Tutorial</item>
         <item>Legend</item>
-        <item>What\'s New?</item>
+        <item>What’s New?</item>
         <item>@string/agencies_title</item>
         <item>Twitter Feed</item>
         <item>Contact Us</item>
@@ -26,7 +26,7 @@
     <string-array name="main_help_options_no_contact_us">
         <item>Show Tutorial</item>
         <item>Legend</item>
-        <item>What\'s New?</item>
+        <item>What’s New?</item>
         <item>@string/agencies_title</item>
         <item>Twitter Feed</item>
     </string-array>
@@ -78,7 +78,7 @@
         <item>It came earlier than predicted</item>
         <item>It came later than predicted</item>
         <item>Wrong destination shown</item>
-        <item>The bus doesn\'t stop here</item>
+        <item>The bus doesn’t stop here</item>
         <item>Something else</item>
     </string-array>
     <string-array name="preferred_map_options">

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -39,39 +39,39 @@
     </string>
 
     <!-- Generic -->
-    <string name="generic_comm_error">Sorry, there was a communication error and we can\'t show this
+    <string name="generic_comm_error">Sorry, there was a communication error and we can’t show this
         information. Try again and it might work.
     </string>
-    <string name="route_not_found_error_no_region">Sorry, that particular route can\'t be found. If
+    <string name="route_not_found_error_no_region">Sorry, that particular route can’t be found. If
         this was a
-        shortcut, it\'s possible your link is out of date, or a region hasn\'t been selected yet
+        shortcut, it’s possible your link is out of date, or a region hasn’t been selected yet
         (Change in
-        \"Preferences->Your region\").
+        “Preferences->Your region”).
     </string>
-    <string name="route_not_found_error_with_region_name">Sorry, that particular route can\'t be
+    <string name="route_not_found_error_with_region_name">Sorry, that particular route can’t be
         found. If this was a
-        shortcut, it\'s possible your link is out of date, or the wrong region is selected (Your
+        shortcut, it’s possible your link is out of date, or the wrong region is selected (Your
         current region is
-        %1$s. Change in \"Preferences->Your region\").
+        %1$s. Change in “Preferences->Your region”).
     </string>
-    <string name="stop_not_found_error_no_region">Sorry, that particular stop can\'t be found. If
+    <string name="stop_not_found_error_no_region">Sorry, that particular stop can’t be found. If
         this was a
-        shortcut, it\'s possible your link is out of date, or a region hasn\'t been selected yet
+        shortcut, it’s possible your link is out of date, or a region hasn’t been selected yet
         (Change in
-        \"Preferences->Your region\").
+        “Preferences->Your region”).
     </string>
-    <string name="stop_not_found_error_with_region_name">Sorry, that particular stop can\'t be
+    <string name="stop_not_found_error_with_region_name">Sorry, that particular stop can’t be
         found. If this was a
-        shortcut, it\'s possible your link is out of date, or the wrong region is selected (Your
+        shortcut, it’s possible your link is out of date, or the wrong region is selected (Your
         current region is
-        %1$s. Change in \"Preferences->Your region\").
+        %1$s. Change in “Preferences->Your region”).
     </string>
     <string name="internal_error">Oops, something went wrong. Please check your Internet connection and try again.</string>
-    <string name="out_of_memory_error">Sorry, there isn\'t enough available memory to handle that
+    <string name="out_of_memory_error">Sorry, there isn’t enough available memory to handle that
         request.
     </string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
-    <string name="bad_gateway_error">%1$s\'s servers are overloaded. Please excuse us!</string>
+    <string name="bad_gateway_error">%1$s’s servers are overloaded. Please excuse us!</string>
     <string name="map_generic_error">Unable to get stops.</string>
     <string name="no_network_error">You appear to be offline or are not connected to the network.
     </string>
@@ -99,14 +99,14 @@
     <string name="map_option_mylocation">My Location</string>
     <string name="map_option_search">Search</string>
     <string name="main_help_title">Help</string>
-    <string name="main_help_whatsnew_title">What\'s New?</string>
+    <string name="main_help_whatsnew_title">What’s New?</string>
     <string name="main_help_whatsnew">• <b>Bug fixes</b> Several bug fixes and fit and finish improvements. - See https://bit.ly/oba-android-releases</string>
     <string name="main_help_close">Close</string>
     <string name="main_help_legend_title">Legend</string>
-    <string name="main_help_legend_ontime">Green means \"On time\"</string>
-    <string name="main_help_legend_late">Blue means \"Running late\"</string>
-    <string name="main_help_legend_early">Red means \"Running early\"</string>
-    <string name="main_help_legend_scheduled">Gray means \"Scheduled arrival\" - We don\'t know
+    <string name="main_help_legend_ontime">Green means “On time”</string>
+    <string name="main_help_legend_late">Blue means “Running late”</string>
+    <string name="main_help_legend_early">Red means “Running early”</string>
+    <string name="main_help_legend_scheduled">Gray means “Scheduled arrival” - We don’t know
         where the bus is now, but the schedule says there is an upcoming arrival
     </string>
     <string name="main_help_legend_canceled">Gray with strikethrough means the trip has been
@@ -121,7 +121,7 @@
     <string name="main_waiting_for_location">Trying to get a fix on your location&#8230;</string>
     <string name="no_location_permission">Unable to get your location.  Please give app location permissions via system settings.</string>
     <string name="main_outofrange_title">Out of range</string>
-    <string name="main_outofrange">You\'re looking at a place outside the %1$s service area.\n\nMove
+    <string name="main_outofrange">You’re looking at a place outside the %1$s service area.\n\nMove
         map to %1$s now?
     </string>
     <string name="main_outofrange_yes">Take me there</string>
@@ -311,7 +311,7 @@
     <string name="feedback_like_button_description">Yes, I was notified at the right time</string>
     <string name="feedback_dislike_button_description">No, I was not notified at the right time</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
-    <string name="feedback_log_guide">Your feedback will be sent to %1$s. If you check \"Include system logs\", real-time location information from your device recorded as you approached your destination stop will be shared with %1$s so developers can improve the destination reminder feature.\n\nChange your preference for sharing system logs in Settings.</string>
+    <string name="feedback_log_guide">Your feedback will be sent to %1$s. If you check “Include system logs”, real-time location information from your device recorded as you approached your destination stop will be shared with %1$s so developers can improve the destination reminder feature.\n\nChange your preference for sharing system logs in Settings.</string>
 
     <!-- Destination reminder feedback Preferences -->
     <string name="preferences_category_user_logs">Share debugging information</string>
@@ -321,9 +321,9 @@
 
     <!-- Destination reminder change location accuracy -->
     <string name="main_changelocationmode_title">High accuracy location not enabled</string>
-    <string name="main_changelocationmode">Your current device "Location method" setting may fail to
+    <string name="main_changelocationmode">Your current device “Location method” setting may fail to
         notify you when approaching your destination due to inaccurate position information.
-        Would you like to change your device "Location method" to "High accuracy" now?
+        Would you like to change your device “Location method” to “High accuracy” now?
     </string>
 
     <!-- Stop Details -->
@@ -334,7 +334,7 @@
     <!-- Route Info  -->
     <string name="route_info_context_get_stop_info">Show arrival information</string>
     <string name="route_info_context_showonmap">Show on map</string>
-    <string name="route_info_no_shape_data">Sorry, map information isn\'t available for this route
+    <string name="route_info_no_shape_data">Sorry, map information isn’t available for this route
     </string>
     <!-- Route map header: switch which direction of the route is shown -->
     <string name="route_header_switch_direction">Switch direction</string>
@@ -360,8 +360,8 @@
     </string>
     <string name="my_no_recent_routes">You have no recent routes.</string>
     <!-- <string name="my_no_starred_routes">You have no starred routes.</string>-->
-    <string name="route_favorite_options_title_star">Star Route \"%s\" for:</string>
-    <string name="route_favorite_options_title_unstar">Remove star from \"%s\" for:</string>
+    <string name="route_favorite_options_title_star">Star Route “%s” for:</string>
+    <string name="route_favorite_options_title_unstar">Remove star from “%s” for:</string>
 
     <string name="my_option_clear_recent_stops">Clear recent stops</string>
     <string name="my_option_clear_recent_routes">Clear recent routes</string>
@@ -444,7 +444,7 @@
 
 
     <!--  Trip list -->
-    <string name="trip_list_notrips">You don\'t have any reminders.\n\nYou can create reminders by
+    <string name="trip_list_notrips">You don’t have any reminders.\n\nYou can create reminders by
         tapping on an arriving bus at your stop.
     </string>
     <string name="trip_list_context_edit">Edit trip</string>
@@ -517,7 +517,7 @@
     <string name="region_selected_auto">selected automatically</string>
     <string name="region_selected_manually">selected manually</string>
     <string name="region_region_found">Found %1$s region</string>
-    <string name="region_load_failed_title">Couldn\'t load regions</string>
+    <string name="region_load_failed_title">Couldn’t load regions</string>
     <string name="region_load_failed_message">Check your connection and try again.</string>
 
     <!--  Bug report -->
@@ -558,7 +558,7 @@
     <!-- Android Maps v2 -->
     <string name="install_google_maps_positive_button">Install</string>
     <string name="please_install_google_maps_dialog_title">Please install Google Maps</string>
-    <string name="no_play_store">Your device doesn\'t have the Play Store installed. Please find
+    <string name="no_play_store">Your device doesn’t have the Play Store installed. Please find
         another way to install Google Maps.
     </string>
     <string name="ok">OK</string>
@@ -605,7 +605,7 @@
 
     <string name="preferences_show_header_arrivals_title">Show arrivals above stop name</string>
     <string name="preferences_show_header_arrivals_summary">When viewing starred stops,
-        show arrival info in the header at the top of the screen (doesn\'t affect map view)
+        show arrival info in the header at the top of the screen (doesn’t affect map view)
     </string>
 
     <string name="preferences_trip_plan_notifications_title">Trip plan notifications (beta)</string>
@@ -639,7 +639,7 @@
     <string name="preferences_save_summary">Saves your starred and recent stops and routes</string>
     <string name="preferences_restore_title">Restore from storage</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
-    <string name="preferences_restore_summary">Restores from a previous backup. After selecting this option, you\'ll be asked to pick a file. Please select the backup file (e.g., "db.backup" or "%1$s.backup"), which may be in your "Documents" folder or any location where you saved the backup.</string>
+    <string name="preferences_restore_summary">Restores from a previous backup. After selecting this option, you’ll be asked to pick a file. Please select the backup file (e.g., “db.backup” or “%1$s.backup”), which may be in your “Documents” folder or any location where you saved the backup.</string>
 
     <string name="preferences_db_saved">Saved successfully!</string>
     <string name="preferences_db_save_error">Unable to save: %1$s</string>
@@ -661,7 +661,7 @@
         unstable and without real-time info! Go ahead?
     </string>
     <string name="preferences_experimental_regions_disable_warning">Your current experimental region
-        won\'t be available! Go ahead?
+        won’t be available! Go ahead?
     </string>
     <string name="preferences_analytics_title">Send anonymous usage data</string>
     <string name="preferences_analytics_summary">Help us improve the app</string>
@@ -704,7 +704,7 @@
     <!-- Issue reporting implementation-->
     <string name="region_dialog_message">Are you in the %1$s region?</string>
     <string name="preference_region_dialog_message"> Your region is currently set to %1$s.
-    If we got this wrong, please tap on \'Your Region\' to change it!</string>
+    If we got this wrong, please tap on ’Your Region’ to change it!</string>
     <string name="preference_region_dialog_title">Please check region</string>
     <string name="report_dialog_stop_header">Please tap on stop on map</string>
 
@@ -716,8 +716,8 @@
     <string name="ri_button_camera">Camera</string>
     <string name="ri_button_gallery">Gallery</string>
     <string name="ri_address_not_found">Address not found. Please check your address.</string>
-    <string name="ri_open_camera_problem">Camera couldn\'t be opened.</string>
-    <string name="ri_resize_image_problem">Image couldn\'t be resized - using full size.</string>
+    <string name="ri_open_camera_problem">Camera couldn’t be opened.</string>
+    <string name="ri_resize_image_problem">Image couldn’t be resized - using full size.</string>
     <string name="ri_service_default">Choose a Problem</string>
     <string name="ri_service_stop">Stop Problem</string>
     <string name="ri_service_trip">Arrival Time Problem</string>
@@ -795,7 +795,7 @@
     <!-- Night Light -->
     <string name="night_light_dialog_title">Never miss the bus at night again!</string>
     <string name="night_light_dialog_message">Tired of watching your bus fly by because the driver
-        couldn\'t see you in the dark? Hold up your flashing Night Light and make yourself visible!
+        couldn’t see you in the dark? Hold up your flashing Night Light and make yourself visible!
         \n\nWARNING: This feature may potentially trigger seizures for people with photosensitive epilepsy. User discretion is advised.
     </string>
     <string name="night_light_create_shortcut">Create shortcut</string>
@@ -814,7 +814,7 @@
     <string name="tutorial_arrival_header_arrival_info_title">How long until your bus arrives?
     </string>
     <string name="tutorial_arrival_header_arrival_info_text">This long! Colored background tells you
-        if the bus is early (red) or late (blue). On time = green background. If we don\'t know
+        if the bus is early (red) or late (blue). On time = green background. If we don’t know
         where the bus is, the scheduled time is shown (gray background). Gray with strikethrough text
         (a line through it) means the trip is canceled.
     </string>
@@ -828,14 +828,14 @@
         routes to the top of the sliding panel.
     </string>
     <string name="tutorial_recent_stops_routes_title">Recent stops and routes</string>
-    <string name="tutorial_recent_stops_routes_text">Find the stops and routes that you\'ve recently
-        looked at via the \"More\" button at the top right of the screen.
+    <string name="tutorial_recent_stops_routes_text">Find the stops and routes that you’ve recently
+        looked at via the “More” button at the top right of the screen.
     </string>
     <!-- Onboarding spotlight card: the corner close button's accessibility label + the final-step action -->
     <string name="tutorial_button_close">End tutorial</string>
     <string name="tutorial_button_finish">Finish</string>
     <!-- The welcome onboarding step that spotlights a real stop on the map -->
-    <string name="tutorial_welcome_map_stop_title">Here\'s a stop</string>
+    <string name="tutorial_welcome_map_stop_title">Here’s a stop</string>
     <string name="tutorial_welcome_map_stop_text">Tap a green dot like this one on the map to see its
         arrival times.
     </string>
@@ -854,7 +854,7 @@
     <string name="about_welcome_title">Welcome to %1$s!</string>
     <string name="about_intro">%1$s is made by a team of volunteers and relies upon the dedication, passion, and talents of its open source contributors.</string>
     <string name="about_contributors_header">Code Contributors:</string>
-    <string name="about_contributors_intro">Our dedicated contributors improve the app\'s functionality and user experience:</string>
+    <string name="about_contributors_intro">Our dedicated contributors improve the app’s functionality and user experience:</string>
     <string name="about_translations_header">Translations:</string>
     <string name="about_translations_intro">Thanks to our translators, %1$s is accessible worldwide:</string>
     <string name="about_image_credits_header">Image Credits:</string>
@@ -921,7 +921,7 @@
     <string name="tripplanner_error_system">Please check your Internet connection and try again.
     </string>
     <string name="tripplanner_error_outside_bounds">Origin or destination is outside transportation network coverage</string>
-    <string name="tripplanner_error_path_not_found">Couldn\'t find a matching route between origin and destination</string>
+    <string name="tripplanner_error_path_not_found">Couldn’t find a matching route between origin and destination</string>
     <string name="tripplanner_error_no_transit_times">Transit times for selected date are not available</string>
     <string name="tripplanner_error_bogus_parameter">Something went wrong.  Change your trip options and try again.</string>
     <string name="tripplanner_error_geocode_from_not_found">Origin not found</string>
@@ -1123,18 +1123,18 @@
     <string name="donation_view_body">This app is currently built with 100% volunteer labor, and we need you to help us fund future development.</string>
     <string name="donation_view_learn_more_button">Learn More</string>
     <string name="donation_view_donate_now_button">Donate Now</string>
-    <string name="donation_dismiss_dialog_title">Please don\'t dismiss this request</string>
+    <string name="donation_dismiss_dialog_title">Please don’t dismiss this request</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <string name="donation_dismiss_dialog_body">%1$s is a volunteer-run organization with almost no funding. We need your help to keep this app running.</string>
-    <string name="donation_dismiss_dialog_dont_want_to_help_button">I Don\'t Want to Help</string>
+    <string name="donation_dismiss_dialog_dont_want_to_help_button">I Don’t Want to Help</string>
     <string name="donation_dismiss_dialog_remind_me_later_button">Remind Me Later</string>
     <string name="donation_dismiss_dialog_cancel_button">Cancel</string>
     <string name="title_activity_donation_learn_more">Why we need your help</string>
     <!-- Note: %1$s is replaced with app_name for white-label support -->
     <!-- "(c)" here is the "501(c)(3)" US tax-code designation, not a copyright symbol. -->
-    <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">We have big plans to improve %1$s, but we can\'t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let\'s shape the future of transit together!\n\nThank you,\nThe %1$s Team</string>
+    <string name="donation_learn_more_explanation" tools:ignore="TypographyOther">We have big plans to improve %1$s, but we can’t do it without your help. This app is currently built with 100%% volunteer labor, and we need you to help us fund future development.\n\nAs a key project of the Open Transit Software Foundation, a 501(c)(3) non-profit, we rely on the goodwill of users like you to keep running and making this software better.\n\nEvery year, only a small fraction of our users donate, but every contribution, big or small, helps ensure that %1$s remains free, updated, and accessible to everyone. A small donation, even just the cost of one week of commuting, $27.50, can make all the difference.\n\nYour tax-deductible contribution ensures that %1$s remains free and accessible for everyone. Let’s shape the future of transit together!\n\nThank you,\nThe %1$s Team</string>
     <string name="preferences_reset_donation_timestamps_title">Reset Donation Timestamps</string>
-    <string name="preferences_reset_donation_timestamps_summary">Tapping this option will clear both the \'Remind Me Later\' and \'Don\'t Bother Me\' timestamps associated with donation requests.</string>
+    <string name="preferences_reset_donation_timestamps_summary">Tapping this option will clear both the ‘Remind Me Later’ and ‘Don’t Bother Me’ timestamps associated with donation requests.</string>
     <string name="preferences_show_weather_view">Show weather view</string>
     <string name="preferences_preferred_maps_title">Preferred Map Type</string>
     <string name="preferences_preferred_map_option_normal2d">Default Map</string>


### PR DESCRIPTION
Stacked on #54 (shares its trimmed baseline). Retarget to `main` once #54 merges.

Pops the base-file `TypographyQuotes` findings off the baseline by fixing them at the source: converts straight quotes to typographic ones in the English `res/values/strings.xml` and `arrays.xml`.

- escaped apostrophes `\'` → `’` (curly; escaping no longer needed)
- straight double-quote pairs → `“ … ”`
- straight single-quote pairs → `‘ … ’`

**Fixed each affected string completely, not just the reported line.** Lint emits one `TypographyQuotes` per string, so fixing only the flagged apostrophe on a string that *also* has a straight quote pair (e.g. `main_help_legend_scheduled`, the region-not-found errors) would just surface the quote as a *new* issue. The strict gate confirms zero residuals.

**Deliberately left untouched:**
- `bus_options_menu_show_all_routes` / `sharing_survey_info_message` wrap the *whole value* in quotes — Android's whitespace-preservation idiom, where the quotes aren't part of the value (which is why lint never flagged them). Curling them would inject literal curly quotes into the string.
- Translation files (`values-it/-fi/-es/-pl`): localized copy with per-language quote conventions — left for translators, still baselined (105 entries remain).

Baseline: 300 → 261 entries.

## Verification
`./gradlew :onebusaway-android:lintObaGoogleDebug -PwarningsAsErrors=true` → **"Lint found no new issues (and 261 errors filtered by baseline)"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LNY6AbWaCJxgzUdnVtZba