### PR TITLE
Long-press the home map for "directions from/to here"

### DIFF
--- a/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
+++ b/onebusaway-android/src/google/java/org/onebusaway/android/map/googlemapsv2/compose/GoogleComposeAdapter.kt
@@ -324,6 +324,10 @@ private fun wireClicks(
         cb.onMapClick(GeoPoint(latLng.latitude, latLng.longitude))
     }
 
+    map.setOnMapLongClickListener { latLng ->
+        cb.onMapLongClick(GeoPoint(latLng.latitude, latLng.longitude))
+    }
+
     map.setOnMarkerClickListener { marker -> routeMarkerTap(marker, renderer, infoWindows, cb) }
 
     map.setOnInfoWindowClickListener { marker ->

--- a/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/map/compose/ObaMapCallbacks.kt
@@ -34,6 +34,9 @@ interface ObaMapCallbacks {
 
     fun onMapClick(point: GeoPoint?)
 
+    /** A long-press on the map at [point] — the host offers "directions from/to here". */
+    fun onMapLongClick(point: GeoPoint) {}
+
     fun onBikeClick(station: BikeStation)
 
     /** A vehicle marker tap — the host selects it (e.g. to show its most-recent-data marker). */

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/HomeScreen.kt
@@ -73,6 +73,7 @@ import org.onebusaway.android.ui.arrivals.ArrivalsUiState
 import org.onebusaway.android.ui.nav.ReminderEditorArgs
 import org.onebusaway.android.map.RouteHeader
 import org.onebusaway.android.map.MapViewModel
+import org.onebusaway.android.map.render.GeoPoint
 import org.onebusaway.android.ui.arrivals.ArrivalsViewModel
 import org.onebusaway.android.ui.compose.ListUiState
 import org.onebusaway.android.ui.compose.findActivity
@@ -85,6 +86,7 @@ import org.onebusaway.android.ui.home.chrome.MAP_TOP_CHROME_CLEARANCE
 import org.onebusaway.android.ui.home.chrome.MapTopChrome
 import org.onebusaway.android.ui.home.chrome.mapTopChromeOverlayInset
 import org.onebusaway.android.ui.home.directions.DirectionsFormCard
+import org.onebusaway.android.ui.home.directions.DirectionsLongPressMenu
 import org.onebusaway.android.ui.home.directions.DirectionsMessageCard
 import org.onebusaway.android.ui.home.directions.DirectionsPickOverlay
 import org.onebusaway.android.ui.home.directions.DirectionsPickTarget
@@ -551,6 +553,8 @@ fun HomeScreen(
                     val directionsLoading = tripPlanResult is PlanResult.Loading
                     // Which endpoint (if any) is being picked directly on the map (crosshair + confirm).
                     var pickTarget by rememberSaveable { mutableStateOf<DirectionsPickTarget?>(null) }
+                    // A long-pressed map point awaiting the "directions from/to here" choice.
+                    var longPressPoint by remember { mutableStateOf<GeoPoint?>(null) }
                     // Leaving directions ends any in-progress map pick.
                     LaunchedEffect(directionsActive) { if (!directionsActive) pickTarget = null }
                     // While planning but not yet submittable (no results), clear any stale drawn itinerary.
@@ -580,6 +584,7 @@ fun HomeScreen(
                             mapViewModel = mapViewModel,
                             homeViewModel = homeViewModel,
                             fabBottomInset = fabInsetTarget,
+                            onMapLongPress = { longPressPoint = it },
                             modifier = Modifier.fillMaxSize(),
                         )
                         // The floating top chrome + the map overlays draw over the (now edge-to-edge) map.
@@ -702,6 +707,24 @@ fun HomeScreen(
                                     pickTarget = null
                                 },
                                 onCancel = { pickTarget = null },
+                            )
+                        }
+                        // Long-press → "directions from/to here": enters directions and fills the endpoint
+                        // with the pressed point (which auto-plans once both endpoints are set).
+                        longPressPoint?.let { point ->
+                            val mapPoint = TripEndpoint.MapPoint(point.latitude, point.longitude)
+                            DirectionsLongPressMenu(
+                                onFromHere = {
+                                    homeViewModel.enterDirections(mapViewModel.viewport)
+                                    tripPlanViewModel.setFrom(mapPoint)
+                                    longPressPoint = null
+                                },
+                                onToHere = {
+                                    homeViewModel.enterDirections(mapViewModel.viewport)
+                                    tripPlanViewModel.setTo(mapPoint)
+                                    longPressPoint = null
+                                },
+                                onDismiss = { longPressPoint = null },
                             )
                         }
                     }

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/directions/DirectionsFeature.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.text.format.DateFormat
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -37,13 +38,17 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -226,6 +231,35 @@ fun DirectionsResultsSheet(
             showItinerary = showItinerary,
             modifier = Modifier.fillMaxWidth(),
         )
+    }
+}
+
+/**
+ * The modal menu shown when the user long-presses the map: "directions from here" / "directions to
+ * here", each of which enters directions focus and fills that endpoint with the pressed point.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DirectionsLongPressMenu(
+    onFromHere: () -> Unit,
+    onToHere: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(Modifier.navigationBarsPadding()) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.directions_from_here)) },
+                leadingContent = {
+                    Icon(painterResource(R.drawable.ic_my_location), contentDescription = null)
+                },
+                modifier = Modifier.clickable(onClick = onFromHere),
+            )
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.directions_to_here)) },
+                leadingContent = { Icon(Icons.Default.Place, contentDescription = null) },
+                modifier = Modifier.clickable(onClick = onToHere),
+            )
+        }
     }
 }
 

--- a/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
+++ b/onebusaway-android/src/main/java/org/onebusaway/android/ui/home/map/MapFeature.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -124,10 +125,14 @@ fun MapFeature(
     // The sheet-driven FAB lift, computed by HomeScreen from its live SheetState (the map composes only
     // when HOME is the destination, so this lives with the sheet rather than round-tripping the VM).
     fabBottomInset: Dp,
+    // A long-press on the map surfaces the "directions from/to here" menu; HomeScreen owns that state.
+    onMapLongPress: (GeoPoint) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val resources = LocalResources.current
+    // Keep the remembered ObaMapCallbacks calling HomeScreen's latest long-press handler.
+    val currentOnMapLongPress by rememberUpdatedState(onMapLongPress)
 
     // Compose-native permission launcher: deliver the result to the map view model (blue dot) + the
     // home view model (the deferred first-launch region check).
@@ -163,6 +168,10 @@ fun MapFeature(
 
             override fun onMapClick(point: GeoPoint?) {
                 homeViewModel.unfocusMapOneLevel()
+            }
+
+            override fun onMapLongClick(point: GeoPoint) {
+                currentOnMapLongPress(point)
             }
 
             override fun onBikeClick(station: BikeStation) {

--- a/onebusaway-android/src/main/res/values/strings.xml
+++ b/onebusaway-android/src/main/res/values/strings.xml
@@ -912,6 +912,8 @@
     <string name="trip_plan_pick_on_map">Pick location on map</string>
     <string name="trip_plan_use_this_location">Use this location</string>
     <string name="trip_plan_map_location">Selected location</string>
+    <string name="directions_from_here">Directions from here</string>
+    <string name="directions_to_here">Directions to here</string>
     <string name="trip_plan_clear_endpoint">Clear</string>
 
 

--- a/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
+++ b/onebusaway-android/src/maplibre/java/org/onebusaway/android/map/maplibre/compose/MapLibreComposeAdapter.kt
@@ -298,6 +298,10 @@ private fun wireClicks(
         callbacks.onMapClick(null)
         false
     }
+    map.addOnMapLongClickListener { point ->
+        callbacks.onMapLongClick(GeoPoint(point.latitude, point.longitude))
+        true
+    }
     map.setOnMarkerClickListener { tapped ->
         // A tap on the ping ripple routes through to the vehicle it's centered on (maplibre classic markers
         // can't be made non-interactive like Google's Circle), so it doesn't swallow the vehicle tap (#1764).


### PR DESCRIPTION
Stacked on top of the trip-planner → home-map directions work (OneBusAway#1872).

## Summary

Long-pressing anywhere on the home map opens a modal menu — **"Directions from here"** and **"Directions to here"** — which enters the directions focus and fills that endpoint with the pressed point. Once the other endpoint is set, the plan auto-fires (with the error / no-route feedback from the base PR).

## Changes

- `ObaMapCallbacks.onMapLongClick(GeoPoint)` (default no-op).
- Wired `setOnMapLongClickListener` (Google) / `addOnMapLongClickListener` (MapLibre) in the two compose adapters.
- Surfaced through `MapFeature` (`onMapLongPress`) to `HomeScreen`, which shows `DirectionsLongPressMenu` (a `ModalBottomSheet`) and, on selection, `enterDirections()` + `setFrom`/`setTo(MapPoint)`.

## Notes

- Base branch is `feature/trip-plan-map-overlay`; retarget to `main` once that PR merges.
- Both flavors (`obaGoogle` + `obaMaplibre`) compile clean under `-PwarningsAsErrors=true`.